### PR TITLE
[#109] feat(iks): refine section blocks colors and fix publication tests

### DIFF
--- a/backend/api/v1/v1_publication/tests/tests_admin_manage_publications_endpoint.py
+++ b/backend/api/v1/v1_publication/tests/tests_admin_manage_publications_endpoint.py
@@ -20,9 +20,9 @@ class PublicationViewSetTestCase(APITestCase):
         call_command("generate_admin_seeder", "--test", True)
         call_command("fake_users_seeder", "--test", True, "--repeat", 3)
         self.user = (
-            SystemUser.objects.filter(
-                role=UserRoleTypes.admin
-            ).order_by("?").first()
+            SystemUser.objects.filter(role=UserRoleTypes.admin)
+            .order_by("?")
+            .first()
         )
         self.client.force_authenticate(user=self.user)
 
@@ -92,10 +92,7 @@ class PublicationViewSetTestCase(APITestCase):
             ],
         )
         publication = Publication.objects.get(pk=data["id"])
-        self.assertEqual(
-            publication.reviews.count(),
-            2
-        )
+        self.assertEqual(publication.reviews.count(), 2)
 
     def test_publication_list(self):
         call_command("fake_publications_seeder", "--test", True)
@@ -109,13 +106,17 @@ class PublicationViewSetTestCase(APITestCase):
         )
         self.assertCountEqual(
             sorted(list(data["data"][0])),
-            sorted([
-                "id",
-                "year_month",
-                "due_date",
-                "initial_values",
-                "status",
-            ])
+            sorted(
+                [
+                    "id",
+                    "year_month",
+                    "due_date",
+                    "initial_values",
+                    "status",
+                    "updated_at",
+                    "progress_reviews",
+                ]
+            ),
         )
 
     def test_publication_detail(self):
@@ -130,14 +131,11 @@ class PublicationViewSetTestCase(APITestCase):
         )
         url = reverse(
             "publication-details",
-            kwargs={"version": "v1", "pk": publication.id}
+            kwargs={"version": "v1", "pk": publication.id},
         )
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json()["id"],
-            publication.id
-        )
+        self.assertEqual(response.json()["id"], publication.id)
 
     def test_update_publication(self):
         publication = Publication.objects.create(
@@ -151,7 +149,7 @@ class PublicationViewSetTestCase(APITestCase):
         )
         url = reverse(
             "publication-details",
-            kwargs={"version": "v1", "pk": publication.id}
+            kwargs={"version": "v1", "pk": publication.id},
         )
         data = {
             "validated_values": [
@@ -186,7 +184,7 @@ class PublicationViewSetTestCase(APITestCase):
         )
         url = reverse(
             "publication-details",
-            kwargs={"version": "v1", "pk": publication.id}
+            kwargs={"version": "v1", "pk": publication.id},
         )
         response = self.client.delete(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -222,7 +220,7 @@ class PublicationViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json(),
-            {"reviewers": ["Please select at least one reviewer."]}
+            {"reviewers": ["Please select at least one reviewer."]},
         )
 
     @patch("django.utils.timezone.now")
@@ -253,6 +251,5 @@ class PublicationViewSetTestCase(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.json(),
-            {"due_date": ["The date must be today or later."]}
+            response.json(), {"due_date": ["The date must be today or later."]}
         )

--- a/backend/api/v1/v1_publication/tests/tests_admin_publication_review_details_endpoint.py
+++ b/backend/api/v1/v1_publication/tests/tests_admin_publication_review_details_endpoint.py
@@ -19,9 +19,9 @@ class PublicationReviewDetailsTestCase(APITestCase):
         call_command("generate_admin_seeder", "--test", True)
         call_command("fake_users_seeder", "--test", True, "--repeat", 3)
         self.user = (
-            SystemUser.objects.filter(
-                role=UserRoleTypes.admin
-            ).order_by("?").first()
+            SystemUser.objects.filter(role=UserRoleTypes.admin)
+            .order_by("?")
+            .first()
         )
         self.client.force_authenticate(user=self.user)
 
@@ -39,10 +39,13 @@ class PublicationReviewDetailsTestCase(APITestCase):
             ],
             due_date="2025-02-28",
         )
-        publication.reviews.set([
-            Review(publication=publication, user=reviewer)
-            for reviewer in self.reviewers
-        ], bulk=False)
+        publication.reviews.set(
+            [
+                Review(publication=publication, user=reviewer)
+                for reviewer in self.reviewers
+            ],
+            bulk=False,
+        )
         for reviewer in publication.reviews.all():
             reviewer.suggestion_values = [
                 {"administration_id": 1253002, "category": "d1"},
@@ -72,7 +75,7 @@ class PublicationReviewDetailsTestCase(APITestCase):
                 "created_at",
                 "updated_at",
                 "completed_at",
-            ]
+            ],
         )
         self.assertEqual(
             list(data["publication"]),
@@ -82,7 +85,9 @@ class PublicationReviewDetailsTestCase(APITestCase):
                 "due_date",
                 "initial_values",
                 "status",
-            ]
+                "updated_at",
+                "progress_reviews",
+            ],
         )
         self.assertEqual(
             list(data["user"]),
@@ -92,7 +97,7 @@ class PublicationReviewDetailsTestCase(APITestCase):
                 "email",
                 "email_verified",
                 "technical_working_group",
-            ]
+            ],
         )
 
     def test_error_get_review_not_found(self):

--- a/backend/api/v1/v1_publication/tests/tests_reviewer_manage_reviews_endpoint.py
+++ b/backend/api/v1/v1_publication/tests/tests_reviewer_manage_reviews_endpoint.py
@@ -20,58 +20,36 @@ from api.v1.v1_publication.serializers import ReviewSerializer
 @override_settings(USE_TZ=False, TEST_ENV=True)
 class ReviewViewSetTestCase(APITestCase):
     def setUp(self):
-        call_command(
-            "generate_administrations_seeder", "--test", True
-        )
-        call_command(
-            "fake_users_seeder", "--test", True, "--repeat", 2
-        )
-        call_command(
-            "fake_publications_seeder", "--test", True
-        )
+        call_command("generate_administrations_seeder", "--test", True)
+        call_command("fake_users_seeder", "--test", True, "--repeat", 2)
+        call_command("fake_publications_seeder", "--test", True)
 
         self.publication = Publication.objects.first()
         self.review = self.publication.reviews.first()
-        self.user = SystemUser.objects.get(
-            pk=self.review.user_id
-        )
+        self.user = SystemUser.objects.get(pk=self.review.user_id)
         self.client.force_authenticate(user=self.user)
 
         # URLs
-        self.list_url = reverse(
-            "review-list",
-            kwargs={"version": "v1"}
-        )
+        self.list_url = reverse("review-list", kwargs={"version": "v1"})
         self.detail_url = lambda pk: reverse(
-            "review-details",
-            kwargs={"version": "v1", "pk": pk}
+            "review-details", kwargs={"version": "v1", "pk": pk}
         )
 
     def test_list_reviews(self):
         response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            len(response.data["data"]), 2
-        )
-        self.assertIn(
-            "progress_review", response.data["data"][0]
-        )
+        self.assertEqual(len(response.data["data"]), 2)
+        self.assertIn("progress_review", response.data["data"][0])
 
     def test_retrieve_review(self):
-        response = self.client.get(
-            self.detail_url(self.review.id)
-        )
+        response = self.client.get(self.detail_url(self.review.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["id"], self.review.id)
         serializer = ReviewSerializer(
-            instance=self.review,
-            context={
-                "total": 59
-            }
+            instance=self.review, context={"total": 59}
         ).data
         self.assertEqual(
-            response.data["progress_review"],
-            serializer["progress_review"]
+            response.data["progress_review"], serializer["progress_review"]
         )
         self.assertEqual(
             list(response.data["publication"]),
@@ -81,7 +59,9 @@ class ReviewViewSetTestCase(APITestCase):
                 "due_date",
                 "initial_values",
                 "status",
-            ]
+                "updated_at",
+                "progress_reviews",
+            ],
         )
 
     def test_create_review(self):
@@ -94,21 +74,17 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 40,
                     "category": None,
                     "administration_id": 1253002,
-                    "reviewed": False
+                    "reviewed": False,
                 },
                 {
                     "value": 2,
                     "category": DroughtCategory.d1,
                     "administration_id": 1253053,
-                    "reviewed": True
-                }
+                    "reviewed": True,
+                },
             ],
         }
-        response = self.client.post(
-            self.list_url,
-            data=payload,
-            format="json"
-        )
+        response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Review.objects.count(), 5)
 
@@ -120,14 +96,14 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 40,
                     "category": DroughtCategory.d2,
                     "administration_id": 1253002,
-                    "reviewed": True
+                    "reviewed": True,
                 },
                 {
                     "value": 2,
                     "category": DroughtCategory.d4,
                     "administration_id": 1253053,
-                    "reviewed": True
-                }
+                    "reviewed": True,
+                },
             ],
         }
         response = self.client.put(
@@ -136,9 +112,7 @@ class ReviewViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         updated_review = Review.objects.get(id=self.review.id)
         self.assertTrue(updated_review.is_completed)
-        self.assertTrue(
-            updated_review.suggestion_values[0]["reviewed"]
-        )
+        self.assertTrue(updated_review.suggestion_values[0]["reviewed"])
 
     def test_publication_in_validation_when_all_reviews_are_completed(self):
         other_reviews = self.publication.reviews.exclude(
@@ -155,14 +129,14 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 35,
                     "category": DroughtCategory.d2,
                     "administration_id": 1253002,
-                    "reviewed": True
+                    "reviewed": True,
                 },
                 {
                     "value": 12,
                     "category": DroughtCategory.d1,
                     "administration_id": 1253053,
-                    "reviewed": True
-                }
+                    "reviewed": True,
+                },
             ],
         }
         response = self.client.put(
@@ -171,8 +145,7 @@ class ReviewViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         updated_publication = Publication.objects.get(id=self.publication.id)
         self.assertEqual(
-            updated_publication.status,
-            PublicationStatus.in_validation
+            updated_publication.status, PublicationStatus.in_validation
         )
 
     def test_list_reviews_pagination(self):
@@ -180,9 +153,7 @@ class ReviewViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("data", response.data)
         self.assertIn("total", response.data)
-        self.assertEqual(
-            response.data["total"], 2
-        )
+        self.assertEqual(response.data["total"], 2)
 
     def test_list_reviews_status_filter(self):
         # Two reviews for this user; mark one completed.
@@ -203,17 +174,15 @@ class ReviewViewSetTestCase(APITestCase):
             f"{self.list_url}?status={FilterStatus.completed}"
         )
         self.assertEqual(completed_res.data["total"], 1)
-        self.assertEqual(
-            completed_res.data["data"][0]["id"], self.review.id
-        )
+        self.assertEqual(completed_res.data["data"][0]["id"], self.review.id)
 
     def _set_review_months(self):
         # year_month is stored with an ARBITRARY day (real data has both the
         # 1st and the last of the month), so the filter must compare by month.
         reviews = list(
-            Review.objects.filter(
-                user_id=self.user.id
-            ).select_related("publication").order_by("id")
+            Review.objects.filter(user_id=self.user.id)
+            .select_related("publication")
+            .order_by("id")
         )
         self.jan_review, self.may_review = reviews[0], reviews[1]
         self.jan_review.publication.year_month = date(2026, 1, 31)
@@ -252,10 +221,7 @@ class ReviewViewSetTestCase(APITestCase):
     def test_permission_denied_for_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.list_url)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_401_UNAUTHORIZED
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_invalid_review_creation(self):
         payload = {
@@ -271,14 +237,12 @@ class ReviewViewSetTestCase(APITestCase):
             "publication_id": self.publication.id,
             "user_id": self.user.id,
             "is_completed": False,
-            "suggestion_values": "OK"
+            "suggestion_values": "OK",
         }
         response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_invalid_reviewed_with_null_category(
-        self
-    ):
+    def test_invalid_reviewed_with_null_category(self):
         payload = {
             "publication_id": self.publication.id,
             "user_id": self.user.id,
@@ -288,22 +252,20 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 40,
                     "administration_id": 1253002,
                     "reviewed": True,  # Reviewed but category is None
-                    "category": None
+                    "category": None,
                 },
                 {
                     "value": 2,
                     "administration_id": 1253053,
                     "reviewed": True,
-                    "category": None
-                }
+                    "category": None,
+                },
             ],
         }
         response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_invalid_update_reviewed_with_null_category(
-        self
-    ):
+    def test_invalid_update_reviewed_with_null_category(self):
         payload = {
             "is_completed": True,
             "suggestion_values": [
@@ -311,14 +273,14 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 40,
                     "administration_id": 1253002,
                     "reviewed": True,  # Invalid: requires category
-                    "category": None
+                    "category": None,
                 },
                 {
                     "value": 2,
                     "administration_id": 1253053,
                     "reviewed": True,
-                    "category": None
-                }
+                    "category": None,
+                },
             ],
         }
         response = self.client.put(
@@ -327,17 +289,10 @@ class ReviewViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_delete_review_by_non_owner(self):
-        non_owner = SystemUser.objects.exclude(
-            pk=self.user.id
-        ).first()
+        non_owner = SystemUser.objects.exclude(pk=self.user.id).first()
         self.client.force_authenticate(user=non_owner)
-        req = self.client.delete(
-            self.detail_url(self.review.id)
-        )
-        self.assertEqual(
-            req.status_code,
-            status.HTTP_404_NOT_FOUND
-        )
+        req = self.client.delete(self.detail_url(self.review.id))
+        self.assertEqual(req.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_create_with_null_category_when_not_reviewed(self):
         """Test that category can be null when reviewed is False"""
@@ -350,28 +305,20 @@ class ReviewViewSetTestCase(APITestCase):
                     "value": 40,
                     "administration_id": 1253002,
                     "reviewed": False,  # Not reviewed, so category can be null
-                    "category": None
+                    "category": None,
                 },
                 {
                     "value": 2,
                     "administration_id": 1253053,
                     "reviewed": True,
-                    "category": DroughtCategory.d1  # Must have value
-                }
+                    "category": DroughtCategory.d1,  # Must have value
+                },
             ],
         }
-        response = self.client.post(
-            self.list_url,
-            data=payload,
-            format="json"
-        )
+        response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    
+
     def test_delete_review(self):
-        response = self.client.delete(
-            self.detail_url(self.review.id)
-        )
+        response = self.client.delete(self.detail_url(self.review.id))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(
-            Review.objects.filter(pk=self.review.id).exists()
-        )
+        self.assertFalse(Review.objects.filter(pk=self.review.id).exists())

--- a/frontend/src/components/Insights/IksTab/IksTab.js
+++ b/frontend/src/components/Insights/IksTab/IksTab.js
@@ -511,6 +511,7 @@ const IksTab = ({
             items={getRainfallPredictors()}
             months={bulkSeries.months}
             indicatorsData={bulkSeries.indicators}
+            section="B"
           />
           <PredictorAccordion
             title="Section C: Seasonal & extreme-weather predictors (8 indicators)"
@@ -518,6 +519,7 @@ const IksTab = ({
             items={getSeasonalPredictors()}
             months={bulkSeries.months}
             indicatorsData={bulkSeries.indicators}
+            section="C"
           />
         </div>
 

--- a/frontend/src/components/Insights/IksTab/IndicatorRow.js
+++ b/frontend/src/components/Insights/IksTab/IndicatorRow.js
@@ -27,6 +27,7 @@ const IndicatorRow = ({
   isDroughtLeaning = false,
   months = [],
   checkedMonths = [],
+  section,
 }) => {
   return (
     <div className="flex items-center justify-between py-2 border-b border-neutral-100 last:border-0 gap-4 bg-white px-4">
@@ -37,9 +38,13 @@ const IndicatorRow = ({
         {(months.length > 0 ? months : Array(12).fill("")).map((m, idx) => {
           const observed = checkedMonths[idx] || false;
           const color = observed
-            ? isDroughtLeaning
-              ? "bg-red-500"
-              : "bg-blue-600"
+            ? section === "B"
+              ? "bg-[#3e5eb9]"
+              : section === "C"
+                ? "bg-[#b10d0b]"
+                : isDroughtLeaning
+                  ? "bg-[#b10d0b]"
+                  : "bg-[#3e5eb9]"
             : "bg-neutral-100";
           const label = m ? formatMonthLabel(m) : `Month ${idx + 1}`;
           return (

--- a/frontend/src/components/Insights/IksTab/PredictorAccordion.js
+++ b/frontend/src/components/Insights/IksTab/PredictorAccordion.js
@@ -10,6 +10,7 @@ const PredictorAccordion = ({
   items,
   months = [],
   indicatorsData = {},
+  section,
 }) => (
   <div className="pb-6">
     <div className="px-4 mb-4">
@@ -40,6 +41,7 @@ const PredictorAccordion = ({
                   isDroughtLeaning={ind.isDroughtLeaning}
                   months={months}
                   checkedMonths={indicatorsData[ind.dbKey] || []}
+                  section={section}
                 />
               ))}
             </div>

--- a/frontend/src/components/Insights/IksTab/__tests__/subcomponents.test.js
+++ b/frontend/src/components/Insights/IksTab/__tests__/subcomponents.test.js
@@ -103,6 +103,34 @@ describe("IksTab Subcomponents", () => {
       );
       expect(screen.getByText("Blue swallows appearance")).toBeInTheDocument();
     });
+
+    it("renders ticked months as blue bg-[#3e5eb9] for Section B", () => {
+      const { container } = render(
+        <IndicatorRow
+          name="Indicator B"
+          months={["2026-01"]}
+          checkedMonths={[true]}
+          section="B"
+        />,
+      );
+      const dot = container.querySelector(".rounded-\\[1px\\]");
+      expect(dot).toHaveClass("bg-[#3e5eb9]");
+      expect(dot).not.toHaveClass("bg-[#b10d0b]");
+    });
+
+    it("renders ticked months as red bg-[#b10d0b] for Section C", () => {
+      const { container } = render(
+        <IndicatorRow
+          name="Indicator C"
+          months={["2026-01"]}
+          checkedMonths={[true]}
+          section="C"
+        />,
+      );
+      const dot = container.querySelector(".rounded-\\[1px\\]");
+      expect(dot).toHaveClass("bg-[#b10d0b]");
+      expect(dot).not.toHaveClass("bg-[#3e5eb9]");
+    });
   });
 
   describe("PredictorAccordion", () => {


### PR DESCRIPTION
# [#109] feat(iks): refine section blocks colors and fix publication tests

## Description

This PR incorporates final QA feedback refinements for the Indigenous Knowledge System (IKS) Explorer dashboard and aligns backend tests with the latest serializer changes.

## Ticket
Closes #109

## Key Changes

### Frontend (Dashboard Colors)
* **Predictor Indicator Blocks**: Configured indicator row grids so that:
  * All checked blocks in **Section B: Rainfall Predictors** render in the brand blue color (`#3e5eb9`).
  * All checked blocks in **Section C: Seasonal & Extreme Weather Predictors** render in the brand red color (`#b10d0b`).
* **Prop Forwarding**: Passed `section="B"` and `section="C"` respectively from `IksTab.js` down through `PredictorAccordion.js` to `IndicatorRow.js`.
* **Jest Unit Tests**: Added and verified tests in `subcomponents.test.js` to assert color-coding constraints based on the new `section` prop.

### Backend (Test alignment)
* **Serializer Fields**: Restructured model serializer assertions in `tests_admin_publication_review_details_endpoint.py`, `tests_admin_manage_publications_endpoint.py`, and `tests_reviewer_manage_reviews_endpoint.py` to match the newly added `updated_at` and `progress_reviews` fields in `PublicationInfoSerializer`.

---

## Testing & Verification

### Automated Tests
* Verified backend test suite passes cleanly:
  ```bash
  docker compose exec backend ./test.sh
  ```
* Verified frontend Jest test suite passes cleanly:
  ```bash
  docker compose exec frontend ./test.sh
  ```
