### PR TITLE
[#163] CDI-E Explorer backend APIs — per-Inkhundla stats + series

### DIFF
--- a/backend/api/v1/v1_jobs/tests.py
+++ b/backend/api/v1/v1_jobs/tests.py
@@ -127,8 +127,11 @@ class CronJobScriptTestCase(SimpleTestCase):
 
     def _job_sh_tasks(self):
         # Task names are the case-branch labels in job.sh, e.g. "  reviews)".
+        # Hyphens count: "cs-reminders" is a task name, and a \w-only pattern
+        # silently drops it from BOTH assertions below — the drift check then
+        # passes while ignoring the very task it should be guarding.
         job_sh = (self.base_dir / "job.sh").read_text()
-        return set(re.findall(r"^\s{2}(\w+)\)", job_sh, re.MULTILINE))
+        return set(re.findall(r"^\s{2}([\w-]+)\)", job_sh, re.MULTILINE))
 
     def _cron_tasks(self):
         cron = (self.base_dir / "eswatini-cron").read_text()

--- a/backend/api/v1/v1_publication/constants.py
+++ b/backend/api/v1/v1_publication/constants.py
@@ -222,6 +222,15 @@ class FilterStatus:
 
 
 class RasterIndicatorTypes:
+    """The CDI component indices extracted per publication.
+
+    Upstream (confirmed with the CDI pipeline 2026-07-27): esi=era5_esi_1mn,
+    evi2=evi2_1mn, sm=noah_soilm_1mn, spi=chirps_spi_3mn. The CDI explorer
+    charts these under titles naming DIFFERENT products ("LST", "NDVI",
+    "SMAP") — that copy is the frontend's; the API only ever speaks in these
+    four keys and their FieldStr names.
+    """
+
     esi = "esi"
     evi2 = "evi2"
     sm = "sm"
@@ -237,6 +246,17 @@ class RasterIndicatorTypes:
     @classmethod
     def choices(cls):
         return list(cls.FieldStr.items())
+
+
+# Every extracted index is a percentile rank on a common 0-1 scale
+# (publication-raster-extraction.md D-4), so one unit token covers all four.
+# There is no mm / °C / m³/m³ anywhere in the CDI explorer.
+PCT_RANK_UNITS = "pct_rank"
+
+# Explorer window bounds. 12 = the Figma D-class strip; 120 caps a crafted
+# from/to so it cannot walk the whole publication history.
+CDI_EXPLORER_DEFAULT_MONTHS = 12
+CDI_EXPLORER_MAX_MONTHS = 120
 
 
 class AdministrationZones(Enum):

--- a/backend/api/v1/v1_publication/insights/serializers.py
+++ b/backend/api/v1/v1_publication/insights/serializers.py
@@ -1,0 +1,49 @@
+from rest_framework import serializers
+
+from api.v1.v1_publication.constants import RasterIndicatorTypes
+
+PERIOD_RE = r"^\d{4}-(0[1-9]|1[0-2])$"
+
+# `from` is a Python keyword, so it cannot be a serializer field name.
+_QUERY_ALIASES = {"from": "from_month", "to": "to_month"}
+
+
+class CDISeriesQuerySerializer(serializers.Serializer):
+    """`from` / `to` / `indicators` for the CDI explorer chart endpoint.
+
+    The span cap is NOT here — with only `from` supplied the span is not
+    knowable until `to` has fallen back to the latest published month, so
+    `insights.utils.resolve_window` enforces it (also as a 400).
+    """
+
+    from_month = serializers.RegexField(PERIOD_RE, required=False)
+    to_month = serializers.RegexField(PERIOD_RE, required=False)
+    indicators = serializers.CharField(required=False)
+
+    @classmethod
+    def from_query_params(cls, query_params):
+        return cls(
+            data={
+                _QUERY_ALIASES.get(key, key): value
+                for key, value in query_params.items()
+                if key in ("from", "to", "indicators")
+            }
+        )
+
+    def validate_indicators(self, value):
+        keys = [key.strip() for key in value.split(",") if key.strip()]
+        unknown = [
+            key for key in keys if key not in RasterIndicatorTypes.FieldStr
+        ]
+        if unknown:
+            raise serializers.ValidationError(
+                "Unknown indicator(s): {0}".format(", ".join(unknown))
+            )
+        return list(dict.fromkeys(keys))
+
+    def validate(self, attrs):
+        from_month = attrs.get("from_month")
+        to_month = attrs.get("to_month")
+        if from_month and to_month and from_month > to_month:
+            raise serializers.ValidationError("'from' must not be after 'to'")
+        return attrs

--- a/backend/api/v1/v1_publication/insights/utils.py
+++ b/backend/api/v1/v1_publication/insights/utils.py
@@ -7,6 +7,7 @@ time, so an unpublished month already has indicator values in the database and
 serving them would both leak a map still under review and run the charts a
 month ahead of the strip beside them.
 """
+from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from api.v1.v1_publication.constants import (
@@ -23,35 +24,35 @@ from utils.periods import month_range, month_start, period_span, shift_period
 ALL_INDICATORS = list(RasterIndicatorTypes.FieldStr)
 
 
-def latest_published_month():
-    """The newest published month as 'YYYY-MM', or None."""
-    year_month = (
-        Publication.objects.filter(
-            status=PublicationStatus.published, published_at__isnull=False
-        )
-        .order_by("-year_month")
-        .values_list("year_month", flat=True)
-        .first()
-    )
-    return as_target_month(year_month) if year_month else None
+def has_published_publication() -> bool:
+    return Publication.objects.filter(
+        status=PublicationStatus.published, published_at__isnull=False
+    ).exists()
+
+
+def current_period() -> str:
+    return as_target_month(timezone.now().date())
 
 
 def resolve_window(from_month: str = None, to_month: str = None):
-    """(from_period, to_period), or (None, None) when nothing is published
-    yet and no explicit range was given.
+    """(from_period, to_period) — always a real window.
 
-    The default is the last CDI_EXPLORER_DEFAULT_MONTHS months ending at the
-    latest PUBLISHED month (design D-11) — anchored on publication rather than
-    on today, because CDI publishes 1-2 months in arrears and a
-    calendar-year-to-date default would return a mostly empty strip.
+    The default is the last CDI_EXPLORER_DEFAULT_MONTHS calendar months ending
+    at the CURRENT month, so the strip reads as "the last year" and lines up
+    with the IKS monthly grids beside it.
+
+    Deliberately NOT anchored on the latest published month (the original D-11
+    choice): that made the axis a function of the data, so a database whose
+    newest published map is old — a fresh environment seeded with historical
+    months, or a long publication pause — rendered a strip labelled with those
+    old years instead of recent ones. Publication lag now shows up the honest
+    way, as empty cells on the right.
     """
-    end = to_month or latest_published_month()
-    if not end:
-        return None, None
+    end = to_month or current_period()
     start = from_month or shift_period(end, -(CDI_EXPLORER_DEFAULT_MONTHS - 1))
     # Capped here rather than in the query serializer: with only `from`
     # supplied the span is not knowable until `to` has fallen back to the
-    # latest published month.
+    # current month.
     if period_span(start, end) > CDI_EXPLORER_MAX_MONTHS:
         raise ValidationError(
             f"Range too large (max {CDI_EXPLORER_MAX_MONTHS} months)"
@@ -164,7 +165,12 @@ def build_cards(period, previous_period, values, indicators) -> list:
             "change_pct": _change_pct(value, previous),
         }
         if value is None:
-            meta["reason"] = "no_raster_data"
+            # Distinguish "this index has no raster for the latest published
+            # month" from "nothing was published in the window at all" — the
+            # first is a gap in one dataset, the second is a gap in the map.
+            meta["reason"] = (
+                "no_raster_data" if period else "no_published_data_in_window"
+            )
         cards.append(
             {
                 "key": indicator,
@@ -211,13 +217,13 @@ def administration_stats(administration) -> dict:
         "zone": administration.zone,
         "dclass": current_dclass(administration),
     }
-    from_period, to_period = resolve_window()
-    if not from_period:
+    if not has_published_publication():
         base["data"] = None
         base["breakdown"] = None
         base["meta"] = {"reason": "no_published_data"}
         return base
 
+    from_period, to_period = resolve_window()
     publications = published_in_window(from_period, to_period)
     periods = month_range(from_period, to_period)
     values = raster_values(publications, administration.pk, ALL_INDICATORS)
@@ -227,14 +233,16 @@ def administration_stats(administration) -> dict:
         )
         for publication in publications
     }
-    # The window ends at the latest published month, so the last two entries
-    # are the two most recent published months. Adjacent in this list, not
-    # necessarily adjacent in the calendar — previous_period says which.
-    latest = publications[-1]
+    # The two most recent published months IN THE WINDOW. Adjacent in this
+    # list, not necessarily adjacent in the calendar — previous_period says
+    # which. Both may be absent: the window is anchored on today, so a
+    # publication pause longer than the window leaves it empty, and that must
+    # render as a blank strip rather than raise.
+    latest = publications[-1] if publications else None
     previous = publications[-2] if len(publications) > 1 else None
 
     base["data"] = build_cards(
-        as_target_month(latest.year_month),
+        as_target_month(latest.year_month) if latest else None,
         as_target_month(previous.year_month) if previous else None,
         values,
         ALL_INDICATORS,
@@ -247,8 +255,8 @@ def administration_stats(administration) -> dict:
         ],
     }
     base["meta"] = {
-        "period": as_target_month(latest.year_month),
-        "last_updated": latest.published_at,
+        "period": as_target_month(latest.year_month) if latest else None,
+        "last_updated": latest.published_at if latest else None,
         "from": from_period,
         "to": to_period,
         "months": len(periods),
@@ -264,11 +272,6 @@ def administration_series(
     base = _base(administration)
     indicators = indicators or ALL_INDICATORS
     from_period, to_period = resolve_window(from_month, to_month)
-    if not from_period:
-        base["data"] = None
-        base["meta"] = {"reason": "no_published_data"}
-        return base
-
     publications = published_in_window(from_period, to_period)
     periods = month_range(from_period, to_period)
     values = raster_values(publications, administration.pk, indicators)

--- a/backend/api/v1/v1_publication/insights/utils.py
+++ b/backend/api/v1/v1_publication/insights/utils.py
@@ -1,0 +1,282 @@
+"""CDI Explorer (INS-3) read helpers.
+
+Everything here is derived from PUBLISHED publications only (design D-4). The
+D-class strip, the metric cards and the four charts must share one window and
+one "latest month": component rasters are extracted at publication *create*
+time, so an unpublished month already has indicator values in the database and
+serving them would both leak a map still under review and run the charts a
+month ahead of the strip beside them.
+"""
+from rest_framework.exceptions import ValidationError
+
+from api.v1.v1_publication.constants import (
+    CDI_EXPLORER_DEFAULT_MONTHS,
+    CDI_EXPLORER_MAX_MONTHS,
+    PCT_RANK_UNITS,
+    PublicationStatus,
+    RasterIndicatorTypes,
+)
+from api.v1.v1_publication.models import Publication, PublicationRaster
+from api.v1.v1_publication.utils import as_target_month
+from utils.periods import month_range, month_start, period_span, shift_period
+
+ALL_INDICATORS = list(RasterIndicatorTypes.FieldStr)
+
+
+def latest_published_month():
+    """The newest published month as 'YYYY-MM', or None."""
+    year_month = (
+        Publication.objects.filter(
+            status=PublicationStatus.published, published_at__isnull=False
+        )
+        .order_by("-year_month")
+        .values_list("year_month", flat=True)
+        .first()
+    )
+    return as_target_month(year_month) if year_month else None
+
+
+def resolve_window(from_month: str = None, to_month: str = None):
+    """(from_period, to_period), or (None, None) when nothing is published
+    yet and no explicit range was given.
+
+    The default is the last CDI_EXPLORER_DEFAULT_MONTHS months ending at the
+    latest PUBLISHED month (design D-11) — anchored on publication rather than
+    on today, because CDI publishes 1-2 months in arrears and a
+    calendar-year-to-date default would return a mostly empty strip.
+    """
+    end = to_month or latest_published_month()
+    if not end:
+        return None, None
+    start = from_month or shift_period(end, -(CDI_EXPLORER_DEFAULT_MONTHS - 1))
+    # Capped here rather than in the query serializer: with only `from`
+    # supplied the span is not knowable until `to` has fallen back to the
+    # latest published month.
+    if period_span(start, end) > CDI_EXPLORER_MAX_MONTHS:
+        raise ValidationError(
+            f"Range too large (max {CDI_EXPLORER_MAX_MONTHS} months)"
+        )
+    return start, end
+
+
+def published_in_window(from_period: str, to_period: str) -> list:
+    return list(
+        Publication.objects.filter(
+            status=PublicationStatus.published,
+            published_at__isnull=False,
+            year_month__range=(
+                month_start(from_period),
+                month_start(to_period),
+            ),
+        ).order_by("year_month")
+    )
+
+
+def _pluck(items, administration_id, field):
+    """One Inkhundla's entry out of a ~59-item per-publication JSON blob."""
+    return next(
+        (
+            item.get(field)
+            for item in (items or [])
+            if item.get("administration_id") == administration_id
+        ),
+        None,
+    )
+
+
+def raster_values(publications, administration_id, indicators) -> dict:
+    """{(period, indicator): value} for the window, in one query.
+
+    ponytail: the `values` column is a ~59-item JSON blob scanned in Python.
+    Worst case here is 4 indicators x 120 months = 480 blobs, still trivial.
+    The ceiling is a NATIONAL view (all 59 Tinkhundla in one response), which
+    would scan 59x this per request — that is when a publication_raster_values
+    table earns its migration.
+    """
+    rows = PublicationRaster.objects.filter(
+        publication__in=publications, indicator__in=indicators
+    ).values_list("publication__year_month", "indicator", "values")
+    return {
+        (as_target_month(year_month), indicator): _pluck(
+            values, administration_id, "value"
+        )
+        for year_month, indicator, values in rows
+    }
+
+
+def current_dclass(administration):
+    """This Inkhundla's drought class from the latest PUBLISHED map.
+
+    Lives here rather than in v1_weather (design D-6): every Detailed Insights
+    tab renders the same chip, so the rule needs exactly one definition and it
+    belongs beside the model it reads. Labels and colors stay in frontend
+    config (CLAUDE.md). None when no published month covers this Inkhundla.
+    """
+    publication = (
+        Publication.objects.filter(
+            status=PublicationStatus.published,
+            validated_values__isnull=False,
+        )
+        .order_by("-year_month")
+        .first()
+    )
+    if not publication:
+        return None
+    category = _pluck(
+        publication.validated_values, administration.pk, "category"
+    )
+    if category is None:
+        return None
+    return {
+        "category": category,
+        "period": as_target_month(publication.year_month),
+    }
+
+
+def _change_pct(value, previous):
+    """Signed percent change, or None when there is no meaningful ratio.
+
+    Deliberately None rather than 0 when the previous month is missing or
+    zero — the card then omits its delta row instead of claiming "no change"
+    (design D-8). Direction (arrow, color) is derived from the sign by the
+    frontend.
+    """
+    if value is None or not previous:
+        return None
+    return round((value - previous) / previous * 100, 1)
+
+
+def build_cards(period, previous_period, values, indicators) -> list:
+    cards = []
+    for indicator in indicators:
+        value = values.get((period, indicator))
+        previous = (
+            values.get((previous_period, indicator))
+            if previous_period
+            else None
+        )
+        meta = {
+            "period": period,
+            "previous": previous,
+            "previous_period": (
+                previous_period if previous is not None else None
+            ),
+            "change_pct": _change_pct(value, previous),
+        }
+        if value is None:
+            meta["reason"] = "no_raster_data"
+        cards.append(
+            {
+                "key": indicator,
+                "label": RasterIndicatorTypes.FieldStr[indicator],
+                "value": value,
+                "units": PCT_RANK_UNITS,
+                "meta": meta,
+            }
+        )
+    return cards
+
+
+def build_series(periods, values, indicators) -> list:
+    return [
+        {
+            "key": indicator,
+            "label": RasterIndicatorTypes.FieldStr[indicator],
+            "units": PCT_RANK_UNITS,
+            "data": [
+                {"period": period, "value": values.get((period, indicator))}
+                for period in periods
+            ],
+        }
+        for indicator in indicators
+    ]
+
+
+def _base(administration) -> dict:
+    return {
+        "key": administration.pk,
+        "label": administration.name,
+        "group": administration.region,
+    }
+
+
+def administration_stats(administration) -> dict:
+    """Header context + D-class history strip + the four metric cards.
+
+    Range-independent, so the frontend fetches it once per Inkhundla while
+    /series re-fetches on every picker change (design D-2).
+    """
+    base = _base(administration)
+    base["value"] = {
+        "zone": administration.zone,
+        "dclass": current_dclass(administration),
+    }
+    from_period, to_period = resolve_window()
+    if not from_period:
+        base["data"] = None
+        base["breakdown"] = None
+        base["meta"] = {"reason": "no_published_data"}
+        return base
+
+    publications = published_in_window(from_period, to_period)
+    periods = month_range(from_period, to_period)
+    values = raster_values(publications, administration.pk, ALL_INDICATORS)
+    categories = {
+        as_target_month(publication.year_month): _pluck(
+            publication.validated_values, administration.pk, "category"
+        )
+        for publication in publications
+    }
+    # The window ends at the latest published month, so the last two entries
+    # are the two most recent published months. Adjacent in this list, not
+    # necessarily adjacent in the calendar — previous_period says which.
+    latest = publications[-1]
+    previous = publications[-2] if len(publications) > 1 else None
+
+    base["data"] = build_cards(
+        as_target_month(latest.year_month),
+        as_target_month(previous.year_month) if previous else None,
+        values,
+        ALL_INDICATORS,
+    )
+    base["breakdown"] = {
+        "group": "dclass_history",
+        "data": [
+            {"period": period, "value": categories.get(period)}
+            for period in periods
+        ],
+    }
+    base["meta"] = {
+        "period": as_target_month(latest.year_month),
+        "last_updated": latest.published_at,
+        "from": from_period,
+        "to": to_period,
+        "months": len(periods),
+    }
+    return base
+
+
+def administration_series(
+    administration, from_month=None, to_month=None, indicators=None
+) -> dict:
+    """The chart series. Each Figma chart owns its own date picker, so this is
+    called once per chart with `indicators` narrowed to that chart's index."""
+    base = _base(administration)
+    indicators = indicators or ALL_INDICATORS
+    from_period, to_period = resolve_window(from_month, to_month)
+    if not from_period:
+        base["data"] = None
+        base["meta"] = {"reason": "no_published_data"}
+        return base
+
+    publications = published_in_window(from_period, to_period)
+    periods = month_range(from_period, to_period)
+    values = raster_values(publications, administration.pk, indicators)
+    base["data"] = build_series(periods, values, indicators)
+    base["meta"] = {
+        "from": from_period,
+        "to": to_period,
+        "months": len(periods),
+        "indicators": indicators,
+    }
+    return base

--- a/backend/api/v1/v1_publication/insights/view.py
+++ b/backend/api/v1/v1_publication/insights/view.py
@@ -1,0 +1,105 @@
+"""Track 3: Detailed insights — CDI Explorer backend APIs (INS-3).
+
+Two public endpoints, keyed by Inkhundla:
+- stats   -> header context + D-class history strip + 4 metric cards
+- series  -> the monthly index charts, range- and indicator-filterable
+
+Split because the frame carries four independent date pickers (design D-2):
+/stats is range-independent, /series re-fetches per picker. Both are DB-reads
+only over PUBLISHED publications — no GeoNode call on the read path.
+Design: eswatini-v2/docs/track-3/cdi-explorer-backend-api.md, Figma 3483-57786.
+"""
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.v1.v1_publication.constants import RasterIndicatorTypes
+from api.v1.v1_publication.insights.serializers import (
+    CDISeriesQuerySerializer,
+)
+from api.v1.v1_publication.insights.utils import (
+    administration_series,
+    administration_stats,
+)
+from api.v1.v1_publication.models import Administration
+from utils.default_serializers import DefaultResponseSerializer
+
+
+class CDIExplorerStatsAPI(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        summary="CDI explorer cards + D-class history for an Inkhundla",
+        tags=["CDI Explorer"],
+        responses={
+            200: OpenApiTypes.OBJECT,
+            404: DefaultResponseSerializer,
+        },
+    )
+    def get(self, request, version, administration_id):
+        administration = get_object_or_404(
+            Administration, pk=administration_id
+        )
+        return Response(
+            administration_stats(administration), status=status.HTTP_200_OK
+        )
+
+
+class CDIExplorerSeriesAPI(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        summary="CDI explorer monthly index series for an Inkhundla",
+        tags=["CDI Explorer"],
+        parameters=[
+            OpenApiParameter(
+                name="from",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Inclusive start month, YYYY-MM.",
+            ),
+            OpenApiParameter(
+                name="to",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Inclusive end month, YYYY-MM.",
+            ),
+            OpenApiParameter(
+                name="indicators",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Comma-separated subset of {0}.".format(
+                    ", ".join(RasterIndicatorTypes.FieldStr)
+                ),
+            ),
+        ],
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: DefaultResponseSerializer,
+            404: DefaultResponseSerializer,
+        },
+    )
+    def get(self, request, version, administration_id):
+        administration = get_object_or_404(
+            Administration, pk=administration_id
+        )
+        serializer = CDISeriesQuerySerializer.from_query_params(
+            request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+        return Response(
+            administration_series(
+                administration,
+                from_month=serializer.validated_data.get("from_month"),
+                to_month=serializer.validated_data.get("to_month"),
+                indicators=serializer.validated_data.get("indicators"),
+            ),
+            status=status.HTTP_200_OK,
+        )

--- a/backend/api/v1/v1_publication/tests/mixins.py
+++ b/backend/api/v1/v1_publication/tests/mixins.py
@@ -1,6 +1,4 @@
 """Shared test fixtures for the CDI Explorer (INS-3)."""
-from datetime import date
-
 from django.utils import timezone
 
 from api.v1.v1_publication.constants import (
@@ -12,39 +10,38 @@ from api.v1.v1_publication.models import (
     Publication,
     PublicationRaster,
 )
+from utils.periods import month_start, shift_period
 
 MHLANGATANE = 4588078  # Hhohho / highveld — has published data
 KWALUSENI = 2042786  # Manzini — never appears in any published month
 
-# Ascending. 2026-02 is deliberately absent from the calendar run so the
-# padding is exercised, and 2026-03 is published but carries no decision or
-# raster value for Mhlangatane.
-PUBLISHED_MONTHS = ["2025-12", "2026-01", "2026-03", "2026-04", "2026-05"]
-COVERED_MONTHS = ["2025-12", "2026-01", "2026-04", "2026-05"]
-CATEGORY_BY_MONTH = {
-    "2025-12": 3,
-    "2026-01": 5,
-    "2026-04": 0,
-    "2026-05": 4,
-}
-# (period, indicator) -> value; 2026-05 esi is missing on purpose so one card
-# reports no_raster_data while the others carry a delta.
-VALUE_BY_MONTH = {
-    "2025-12": 0.41,
-    "2026-01": 0.38,
-    "2026-04": 0.22,
-    "2026-05": 0.05,
-}
+
+def period_at(offset: int) -> str:
+    """'YYYY-MM' `offset` months back from the current month."""
+    return shift_period(timezone.now().date().strftime("%Y-%m"), -offset)
 
 
-def month_start(period):
-    year, month = map(int, period.split("-"))
-    return date(year, month, 1)
+# Months back from today. The explorer window is the last 12 calendar months
+# ending at the current month, so everything here lands inside it, and the
+# fixture stays valid whenever it is run — hard-coded 2026 dates would drift
+# out of the window as soon as the clock passed them.
+#
+# Shape is deliberately awkward: offsets 3 and 5 are missing entirely (no
+# publication), offset 4 is published but carries no decision for this
+# Inkhundla, and the latest month is missing its ESI raster. That exercises
+# padding, null strip cells and no_raster_data rather than assuming them.
+LATEST = 1
+PREVIOUS = 2
+DECISIONLESS = 4
+PUBLISHED_OFFSETS = [7, 6, DECISIONLESS, PREVIOUS, LATEST]
+COVERED_OFFSETS = [7, 6, PREVIOUS, LATEST]
+CATEGORY_BY_OFFSET = {7: 3, 6: 5, PREVIOUS: 0, LATEST: 4}
+VALUE_BY_OFFSET = {7: 0.41, 6: 0.38, PREVIOUS: 0.22, LATEST: 0.05}
 
 
 class CDIExplorerDataMixin:
-    """Seeds five published months for Mhlangatane with one gap month, one
-    decision-less month and one missing raster. Compose with APITestCase.
+    """Seeds five published months for Mhlangatane inside the current window,
+    with one gap, one decision-less month and one missing raster.
     """
 
     def setUp(self):
@@ -58,36 +55,37 @@ class CDIExplorerDataMixin:
         self.uncovered = Administration.objects.create(
             pk=KWALUSENI, name="Kwaluseni", region="Manzini"
         )
-        self.publications = {}
-        for index, period in enumerate(PUBLISHED_MONTHS):
-            self.publications[period] = self._publish(period, index)
+        self.publications = {
+            period_at(offset): self._publish(offset, index)
+            for index, offset in enumerate(PUBLISHED_OFFSETS)
+        }
 
-    def _publish(self, period, index):
-        covered = period in COVERED_MONTHS
-        validated = (
-            [
-                {
-                    "administration_id": MHLANGATANE,
-                    "value": 2,
-                    "category": CATEGORY_BY_MONTH[period],
-                }
-            ]
-            if covered
-            else []
-        )
+    def _publish(self, offset, index):
+        covered = offset in COVERED_OFFSETS
+        period = period_at(offset)
         publication = Publication.objects.create(
             cdi_geonode_id=1000 + index,
             year_month=month_start(period),
             due_date=month_start(period),
             initial_values=[],
-            validated_values=validated,
+            validated_values=(
+                [
+                    {
+                        "administration_id": MHLANGATANE,
+                        "value": 2,
+                        "category": CATEGORY_BY_OFFSET[offset],
+                    }
+                ]
+                if covered
+                else []
+            ),
             status=PublicationStatus.published,
             published_at=timezone.now(),
         )
         if not covered:
             return publication
         for indicator in RasterIndicatorTypes.FieldStr:
-            if period == "2026-05" and indicator == RasterIndicatorTypes.esi:
+            if offset == LATEST and indicator == RasterIndicatorTypes.esi:
                 continue
             PublicationRaster.objects.create(
                 publication=publication,
@@ -96,7 +94,7 @@ class CDIExplorerDataMixin:
                 values=[
                     {
                         "administration_id": MHLANGATANE,
-                        "value": VALUE_BY_MONTH[period],
+                        "value": VALUE_BY_OFFSET[offset],
                     }
                 ],
             )

--- a/backend/api/v1/v1_publication/tests/mixins.py
+++ b/backend/api/v1/v1_publication/tests/mixins.py
@@ -1,0 +1,103 @@
+"""Shared test fixtures for the CDI Explorer (INS-3)."""
+from datetime import date
+
+from django.utils import timezone
+
+from api.v1.v1_publication.constants import (
+    PublicationStatus,
+    RasterIndicatorTypes,
+)
+from api.v1.v1_publication.models import (
+    Administration,
+    Publication,
+    PublicationRaster,
+)
+
+MHLANGATANE = 4588078  # Hhohho / highveld — has published data
+KWALUSENI = 2042786  # Manzini — never appears in any published month
+
+# Ascending. 2026-02 is deliberately absent from the calendar run so the
+# padding is exercised, and 2026-03 is published but carries no decision or
+# raster value for Mhlangatane.
+PUBLISHED_MONTHS = ["2025-12", "2026-01", "2026-03", "2026-04", "2026-05"]
+COVERED_MONTHS = ["2025-12", "2026-01", "2026-04", "2026-05"]
+CATEGORY_BY_MONTH = {
+    "2025-12": 3,
+    "2026-01": 5,
+    "2026-04": 0,
+    "2026-05": 4,
+}
+# (period, indicator) -> value; 2026-05 esi is missing on purpose so one card
+# reports no_raster_data while the others carry a delta.
+VALUE_BY_MONTH = {
+    "2025-12": 0.41,
+    "2026-01": 0.38,
+    "2026-04": 0.22,
+    "2026-05": 0.05,
+}
+
+
+def month_start(period):
+    year, month = map(int, period.split("-"))
+    return date(year, month, 1)
+
+
+class CDIExplorerDataMixin:
+    """Seeds five published months for Mhlangatane with one gap month, one
+    decision-less month and one missing raster. Compose with APITestCase.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.administration = Administration.objects.create(
+            pk=MHLANGATANE,
+            name="Mhlangatane",
+            region="Hhohho",
+            zone="highveld",
+        )
+        self.uncovered = Administration.objects.create(
+            pk=KWALUSENI, name="Kwaluseni", region="Manzini"
+        )
+        self.publications = {}
+        for index, period in enumerate(PUBLISHED_MONTHS):
+            self.publications[period] = self._publish(period, index)
+
+    def _publish(self, period, index):
+        covered = period in COVERED_MONTHS
+        validated = (
+            [
+                {
+                    "administration_id": MHLANGATANE,
+                    "value": 2,
+                    "category": CATEGORY_BY_MONTH[period],
+                }
+            ]
+            if covered
+            else []
+        )
+        publication = Publication.objects.create(
+            cdi_geonode_id=1000 + index,
+            year_month=month_start(period),
+            due_date=month_start(period),
+            initial_values=[],
+            validated_values=validated,
+            status=PublicationStatus.published,
+            published_at=timezone.now(),
+        )
+        if not covered:
+            return publication
+        for indicator in RasterIndicatorTypes.FieldStr:
+            if period == "2026-05" and indicator == RasterIndicatorTypes.esi:
+                continue
+            PublicationRaster.objects.create(
+                publication=publication,
+                indicator=indicator,
+                geonode_id=2000 + index,
+                values=[
+                    {
+                        "administration_id": MHLANGATANE,
+                        "value": VALUE_BY_MONTH[period],
+                    }
+                ],
+            )
+        return publication

--- a/backend/api/v1/v1_publication/tests/tests_admin_manage_publications_endpoint.py
+++ b/backend/api/v1/v1_publication/tests/tests_admin_manage_publications_endpoint.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import patch
 from django.utils import timezone
 from rest_framework.test import APITestCase
@@ -253,3 +254,41 @@ class PublicationViewSetTestCase(APITestCase):
         self.assertEqual(
             response.json(), {"due_date": ["The date must be today or later."]}
         )
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class PublicationListOrderingTestCase(APITestCase):
+    """The list is ordered by month, newest first.
+
+    Ordering by -due_date put an older month on top, because publications
+    created together share a due date and tied rows come back in whatever
+    order the database picks — so this pins the column AND the tiebreak.
+    """
+
+    def setUp(self):
+        call_command("generate_administrations_seeder", "--test", True)
+        call_command("generate_admin_seeder", "--test", True)
+        self.admin = SystemUser.objects.filter(
+            role=UserRoleTypes.admin
+        ).first()
+        self.client.force_authenticate(user=self.admin)
+        # Deliberately inserted out of order, all sharing one due date.
+        self.months = ["2026-04", "2026-05", "2026-03"]
+        for index, month in enumerate(self.months):
+            Publication.objects.create(
+                cdi_geonode_id=7100 + index,
+                year_month=date(int(month[:4]), int(month[5:]), 1),
+                due_date=date(2026, 7, 31),
+                initial_values=[],
+            )
+
+    def test_list_is_newest_month_first(self):
+        response = self.client.get(
+            "/api/v1/admin/publications", follow=True
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        months = [
+            row["year_month"][:7] for row in response.json()["data"]
+        ]
+        self.assertEqual(months, sorted(months, reverse=True))
+        self.assertEqual(months[0], "2026-05")

--- a/backend/api/v1/v1_publication/tests/tests_admin_validation_queue_apis.py
+++ b/backend/api/v1/v1_publication/tests/tests_admin_validation_queue_apis.py
@@ -192,8 +192,18 @@ class ValidationQueueAPIsTestCase(APITestCase):
             {
                 "publication_id", "year_month", "published_at", "total",
                 "reviewers_required", "can_publish", "pending_validation",
+                "narrative",
             },
         )
+
+    def test_meta_carries_the_current_narrative(self):
+        """Re-opening the publish modal must edit the live description, not
+        blank it — the page has no other source for it."""
+        text = "Conditions eased across the Lowveld."
+        self.publication.narrative = text
+        self.publication.save()
+        meta = self.client.get(self.stats_url).data["meta"]
+        self.assertEqual(meta["narrative"], text)
 
     def test_status_counts_partition_the_queue(self):
         """D-10: ready + awaiting + validated == total. `disagreement`

--- a/backend/api/v1/v1_publication/tests/tests_admin_validation_queue_apis.py
+++ b/backend/api/v1/v1_publication/tests/tests_admin_validation_queue_apis.py
@@ -192,7 +192,7 @@ class ValidationQueueAPIsTestCase(APITestCase):
             {
                 "publication_id", "year_month", "published_at", "total",
                 "reviewers_required", "can_publish", "pending_validation",
-                "narrative",
+                "narrative", "bulletin_url",
             },
         )
 
@@ -204,6 +204,15 @@ class ValidationQueueAPIsTestCase(APITestCase):
         self.publication.save()
         meta = self.client.get(self.stats_url).data["meta"]
         self.assertEqual(meta["narrative"], text)
+
+    def test_meta_carries_the_current_bulletin_url(self):
+        """Same trap as the narrative: the modal submits the bulletin URL on
+        every update, so a field it cannot prefill is a field it wipes."""
+        url = "https://ndma.org.sz/bulletin-2026-05.pdf"
+        self.publication.bulletin_url = url
+        self.publication.save()
+        meta = self.client.get(self.stats_url).data["meta"]
+        self.assertEqual(meta["bulletin_url"], url)
 
     def test_status_counts_partition_the_queue(self):
         """D-10: ready + awaiting + validated == total. `disagreement`

--- a/backend/api/v1/v1_publication/tests/tests_cdi_explorer_series.py
+++ b/backend/api/v1/v1_publication/tests/tests_cdi_explorer_series.py
@@ -6,7 +6,9 @@ from rest_framework.test import APITestCase
 from api.v1.v1_publication.constants import RasterIndicatorTypes
 from api.v1.v1_publication.tests.mixins import (
     CDIExplorerDataMixin,
+    LATEST,
     MHLANGATANE,
+    period_at,
 )
 
 
@@ -26,8 +28,9 @@ class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
         response = self.get()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         meta = response.json()["meta"]
-        self.assertEqual(meta["from"], "2025-06")
-        self.assertEqual(meta["to"], "2026-05")
+        # Anchored on today, like the strip.
+        self.assertEqual(meta["from"], period_at(11))
+        self.assertEqual(meta["to"], period_at(0))
         self.assertEqual(meta["months"], 12)
         self.assertEqual(
             meta["indicators"], list(RasterIndicatorTypes.FieldStr)
@@ -41,12 +44,14 @@ class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
         self.assertEqual(series["label"], "SPI percentile rank")
         points = {p["period"]: p["value"] for p in series["data"]}
         self.assertEqual(len(points), 12)
-        self.assertEqual(points["2025-12"], 0.41)
-        self.assertEqual(points["2026-05"], 0.05)
-        # no publication at all / published but no value for this Inkhundla
-        self.assertIsNone(points["2025-06"])
-        self.assertIsNone(points["2026-02"])
-        self.assertIsNone(points["2026-03"])
+        self.assertEqual(points[period_at(7)], 0.41)
+        self.assertEqual(points[period_at(LATEST)], 0.05)
+        # no publication at all / published but no value for this Inkhundla /
+        # the current month, which is not published yet
+        self.assertIsNone(points[period_at(11)])
+        self.assertIsNone(points[period_at(5)])
+        self.assertIsNone(points[period_at(4)])
+        self.assertIsNone(points[period_at(0)])
 
     def test_indicator_subset(self):
         data = self.get("?indicators=spi").json()
@@ -54,10 +59,10 @@ class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
         self.assertEqual(data["meta"]["indicators"], ["spi"])
 
     def test_explicit_range(self):
-        data = self.get("?from=2025-12&to=2026-01").json()
+        data = self.get(f"?from={period_at(7)}&to={period_at(6)}").json()
         self.assertEqual(data["meta"]["months"], 2)
         periods = [p["period"] for p in data["data"][0]["data"]]
-        self.assertEqual(periods, ["2025-12", "2026-01"])
+        self.assertEqual(periods, [period_at(7), period_at(6)])
 
     def test_invalid_month_format_is_400(self):
         for query in ("?from=2025-13", "?to=May-2026", "?from=2025"):
@@ -68,13 +73,13 @@ class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
             )
 
     def test_reversed_range_is_400(self):
-        response = self.get("?from=2026-05&to=2025-01")
+        response = self.get(f"?from={period_at(0)}&to={period_at(11)}")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_oversized_range_is_400(self):
         # Both forms: explicit, and `from` alone against the default `to`.
         self.assertEqual(
-            self.get("?from=1900-01&to=2026-05").status_code,
+            self.get(f"?from=1900-01&to={period_at(0)}").status_code,
             status.HTTP_400_BAD_REQUEST,
         )
         self.assertEqual(
@@ -91,6 +96,7 @@ class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_query_count_is_bounded(self):
-        # 4 = administration, latest published, window, rasters.
-        with self.assertNumQueries(4):
+        # 3 = administration, window, rasters. The window is computed from
+        # the clock now, so no "latest published month" lookup is needed.
+        with self.assertNumQueries(3):
             self.get()

--- a/backend/api/v1/v1_publication/tests/tests_cdi_explorer_series.py
+++ b/backend/api/v1/v1_publication/tests/tests_cdi_explorer_series.py
@@ -1,0 +1,96 @@
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.v1.v1_publication.constants import RasterIndicatorTypes
+from api.v1.v1_publication.tests.mixins import (
+    CDIExplorerDataMixin,
+    MHLANGATANE,
+)
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CDIExplorerSeriesTestCase(CDIExplorerDataMixin, APITestCase):
+    def url(self, administration_id=MHLANGATANE, query=""):
+        path = reverse(
+            "cdi-explorer-series",
+            kwargs={"version": "v1", "administration_id": administration_id},
+        )
+        return f"{path}{query}"
+
+    def get(self, query=""):
+        return self.client.get(self.url(query=query))
+
+    def test_public_access_and_default_window(self):
+        response = self.get()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        meta = response.json()["meta"]
+        self.assertEqual(meta["from"], "2025-06")
+        self.assertEqual(meta["to"], "2026-05")
+        self.assertEqual(meta["months"], 12)
+        self.assertEqual(
+            meta["indicators"], list(RasterIndicatorTypes.FieldStr)
+        )
+
+    def test_every_month_present_with_nulls_for_gaps(self):
+        series = next(
+            s for s in self.get().json()["data"] if s["key"] == "spi"
+        )
+        self.assertEqual(series["units"], "pct_rank")
+        self.assertEqual(series["label"], "SPI percentile rank")
+        points = {p["period"]: p["value"] for p in series["data"]}
+        self.assertEqual(len(points), 12)
+        self.assertEqual(points["2025-12"], 0.41)
+        self.assertEqual(points["2026-05"], 0.05)
+        # no publication at all / published but no value for this Inkhundla
+        self.assertIsNone(points["2025-06"])
+        self.assertIsNone(points["2026-02"])
+        self.assertIsNone(points["2026-03"])
+
+    def test_indicator_subset(self):
+        data = self.get("?indicators=spi").json()
+        self.assertEqual([s["key"] for s in data["data"]], ["spi"])
+        self.assertEqual(data["meta"]["indicators"], ["spi"])
+
+    def test_explicit_range(self):
+        data = self.get("?from=2025-12&to=2026-01").json()
+        self.assertEqual(data["meta"]["months"], 2)
+        periods = [p["period"] for p in data["data"][0]["data"]]
+        self.assertEqual(periods, ["2025-12", "2026-01"])
+
+    def test_invalid_month_format_is_400(self):
+        for query in ("?from=2025-13", "?to=May-2026", "?from=2025"):
+            self.assertEqual(
+                self.get(query).status_code,
+                status.HTTP_400_BAD_REQUEST,
+                msg=query,
+            )
+
+    def test_reversed_range_is_400(self):
+        response = self.get("?from=2026-05&to=2025-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_oversized_range_is_400(self):
+        # Both forms: explicit, and `from` alone against the default `to`.
+        self.assertEqual(
+            self.get("?from=1900-01&to=2026-05").status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertEqual(
+            self.get("?from=1900-01").status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_unknown_indicator_is_400(self):
+        response = self.get("?indicators=spi,rainfall")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unknown_administration_is_404(self):
+        response = self.client.get(self.url(administration_id=404404))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_count_is_bounded(self):
+        # 4 = administration, latest published, window, rasters.
+        with self.assertNumQueries(4):
+            self.get()

--- a/backend/api/v1/v1_publication/tests/tests_cdi_explorer_stats.py
+++ b/backend/api/v1/v1_publication/tests/tests_cdi_explorer_stats.py
@@ -1,0 +1,238 @@
+from datetime import date
+
+from django.test.utils import override_settings
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.v1.v1_publication.constants import (
+    PublicationStatus,
+    RasterIndicatorTypes,
+)
+from api.v1.v1_publication.insights.utils import _change_pct
+from api.v1.v1_publication.models import Administration, Publication
+from api.v1.v1_publication.tests.mixins import (
+    CDIExplorerDataMixin,
+    KWALUSENI,
+    MHLANGATANE,
+)
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CDIExplorerStatsTestCase(CDIExplorerDataMixin, APITestCase):
+    def url(self, administration_id=MHLANGATANE):
+        return reverse(
+            "cdi-explorer-stats",
+            kwargs={"version": "v1", "administration_id": administration_id},
+        )
+
+    def test_public_access(self):
+        response = self.client.get(self.url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_header_context(self):
+        data = self.client.get(self.url()).json()
+        self.assertEqual(data["key"], MHLANGATANE)
+        self.assertEqual(data["label"], "Mhlangatane")
+        self.assertEqual(data["group"], "Hhohho")
+        self.assertEqual(data["value"]["zone"], "highveld")
+        self.assertEqual(
+            data["value"]["dclass"], {"category": 4, "period": "2026-05"}
+        )
+
+    def test_window_is_twelve_months_ending_at_latest_published(self):
+        meta = self.client.get(self.url()).json()["meta"]
+        self.assertEqual(meta["period"], "2026-05")
+        self.assertEqual(meta["from"], "2025-06")
+        self.assertEqual(meta["to"], "2026-05")
+        self.assertEqual(meta["months"], 12)
+
+    def test_history_pads_every_month_in_the_window(self):
+        breakdown = self.client.get(self.url()).json()["breakdown"]
+        self.assertEqual(breakdown["group"], "dclass_history")
+        periods = [item["period"] for item in breakdown["data"]]
+        self.assertEqual(len(periods), 12)
+        self.assertEqual(periods[0], "2025-06")
+        self.assertEqual(periods[-1], "2026-05")
+        self.assertEqual(periods, sorted(periods))
+
+        by_period = {i["period"]: i["value"] for i in breakdown["data"]}
+        self.assertEqual(by_period["2025-12"], 3)
+        self.assertEqual(by_period["2026-05"], 4)
+        # never published -> null; published without a decision -> also null
+        self.assertIsNone(by_period["2025-06"])
+        self.assertIsNone(by_period["2026-02"])
+        self.assertIsNone(by_period["2026-03"])
+
+    def test_cards_carry_previous_month_and_signed_change(self):
+        cards = self.client.get(self.url()).json()["data"]
+        self.assertEqual(
+            {card["key"] for card in cards},
+            set(RasterIndicatorTypes.FieldStr),
+        )
+        spi = next(c for c in cards if c["key"] == "spi")
+        self.assertEqual(spi["value"], 0.05)
+        self.assertEqual(spi["units"], "pct_rank")
+        self.assertEqual(spi["label"], "SPI percentile rank")
+        self.assertEqual(spi["meta"]["period"], "2026-05")
+        self.assertEqual(spi["meta"]["previous"], 0.22)
+        self.assertEqual(spi["meta"]["previous_period"], "2026-04")
+        self.assertEqual(spi["meta"]["change_pct"], -77.3)
+
+    def test_card_without_a_raster_reports_the_reason(self):
+        cards = self.client.get(self.url()).json()["data"]
+        esi = next(c for c in cards if c["key"] == "esi")
+        self.assertIsNone(esi["value"])
+        self.assertIsNone(esi["meta"]["change_pct"])
+        self.assertEqual(esi["meta"]["reason"], "no_raster_data")
+
+    def test_inkhundla_with_no_published_decision_still_renders(self):
+        data = self.client.get(self.url(KWALUSENI)).json()
+        self.assertEqual(data["label"], "Kwaluseni")
+        self.assertIsNone(data["value"]["dclass"])
+        self.assertTrue(
+            all(
+                item["value"] is None for item in data["breakdown"]["data"]
+            )
+        )
+        self.assertTrue(
+            all(card["value"] is None for card in data["data"])
+        )
+
+    def test_unpublished_months_are_excluded(self):
+        Publication.objects.create(
+            cdi_geonode_id=9999,
+            year_month=date(2026, 6, 1),
+            due_date=date(2026, 7, 1),
+            initial_values=[],
+            validated_values=[
+                {"administration_id": MHLANGATANE, "value": 1, "category": 5}
+            ],
+            status=PublicationStatus.in_review,
+        )
+        meta = self.client.get(self.url()).json()["meta"]
+        self.assertEqual(meta["period"], "2026-05")
+
+    def test_unknown_administration_is_404(self):
+        response = self.client.get(self.url(404404))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_count_is_bounded(self):
+        # 5 = administration, dclass, latest published, window, rasters.
+        # Independent of window size — the guard against reintroducing an N+1.
+        with self.assertNumQueries(5):
+            self.client.get(self.url())
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CDIExplorerEmptyStateTestCase(APITestCase):
+    def setUp(self):
+        self.administration = Administration.objects.create(
+            pk=MHLANGATANE, name="Mhlangatane", region="Hhohho",
+            zone="highveld",
+        )
+
+    def test_no_published_publication_at_all(self):
+        Publication.objects.create(
+            cdi_geonode_id=1,
+            year_month=date(2026, 5, 1),
+            due_date=date(2026, 6, 1),
+            initial_values=[],
+            status=PublicationStatus.in_review,
+        )
+        response = self.client.get(
+            reverse(
+                "cdi-explorer-stats",
+                kwargs={
+                    "version": "v1",
+                    "administration_id": MHLANGATANE,
+                },
+            )
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # header still renders, so the page is not blank
+        self.assertEqual(data["label"], "Mhlangatane")
+        self.assertEqual(data["value"]["zone"], "highveld")
+        self.assertIsNone(data["data"])
+        self.assertIsNone(data["breakdown"])
+        self.assertEqual(data["meta"]["reason"], "no_published_data")
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CDIExplorerNoDataCategoryTestCase(APITestCase):
+    def test_no_data_category_passes_through_untouched(self):
+        # -9999 is raster output where the CDI had no signal. It is a real
+        # published value, not an absence, and the frontend already maps it to
+        # its own "No data" chip — so it must not be flattened to null here.
+        administration = Administration.objects.create(
+            pk=MHLANGATANE, name="Mhlangatane", region="Hhohho"
+        )
+        Publication.objects.create(
+            cdi_geonode_id=1,
+            year_month=date(2026, 5, 1),
+            due_date=date(2026, 6, 1),
+            initial_values=[],
+            validated_values=[
+                {
+                    "administration_id": administration.pk,
+                    "value": 0,
+                    "category": -9999,
+                }
+            ],
+            status=PublicationStatus.published,
+            published_at=timezone.now(),
+        )
+        data = self.client.get(
+            reverse(
+                "cdi-explorer-stats",
+                kwargs={
+                    "version": "v1",
+                    "administration_id": MHLANGATANE,
+                },
+            )
+        ).json()
+        history = {i["period"]: i["value"] for i in data["breakdown"]["data"]}
+        self.assertEqual(history["2026-05"], -9999)
+        self.assertEqual(data["value"]["dclass"]["category"], -9999)
+
+
+class ChangePctTestCase(APITestCase):
+    def test_signed_and_rounded_to_one_decimal(self):
+        self.assertEqual(_change_pct(0.05, 0.22), -77.3)
+        self.assertEqual(_change_pct(0.5, 0.25), 100.0)
+
+    def test_none_when_no_meaningful_ratio(self):
+        # None rather than 0: the card omits its delta row instead of
+        # claiming "no change" (design D-8).
+        self.assertIsNone(_change_pct(0.4, None))
+        self.assertIsNone(_change_pct(0.4, 0))
+        self.assertIsNone(_change_pct(None, 0.4))
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CurrentDclassParityTestCase(APITestCase):
+    """The weather explorer reads the same helper after the D-6 move."""
+
+    def test_weather_and_cdi_report_the_same_chip(self):
+        from api.v1.v1_weather.services import current_dclass
+
+        administration = Administration.objects.create(
+            pk=MHLANGATANE, name="Mhlangatane", region="Hhohho"
+        )
+        Publication.objects.create(
+            cdi_geonode_id=1,
+            year_month=date(2026, 5, 1),
+            due_date=date(2026, 6, 1),
+            initial_values=[],
+            validated_values=[
+                {"administration_id": MHLANGATANE, "value": 2, "category": 4}
+            ],
+            status=PublicationStatus.published,
+            published_at=timezone.now(),
+        )
+        self.assertEqual(
+            current_dclass(administration),
+            {"category": 4, "period": "2026-05"},
+        )

--- a/backend/api/v1/v1_publication/tests/tests_cdi_explorer_stats.py
+++ b/backend/api/v1/v1_publication/tests/tests_cdi_explorer_stats.py
@@ -12,10 +12,14 @@ from api.v1.v1_publication.constants import (
 )
 from api.v1.v1_publication.insights.utils import _change_pct
 from api.v1.v1_publication.models import Administration, Publication
+from utils.periods import month_start
 from api.v1.v1_publication.tests.mixins import (
     CDIExplorerDataMixin,
     KWALUSENI,
+    LATEST,
     MHLANGATANE,
+    PREVIOUS,
+    period_at,
 )
 
 
@@ -38,32 +42,38 @@ class CDIExplorerStatsTestCase(CDIExplorerDataMixin, APITestCase):
         self.assertEqual(data["group"], "Hhohho")
         self.assertEqual(data["value"]["zone"], "highveld")
         self.assertEqual(
-            data["value"]["dclass"], {"category": 4, "period": "2026-05"}
+            data["value"]["dclass"],
+            {"category": 4, "period": period_at(LATEST)},
         )
 
-    def test_window_is_twelve_months_ending_at_latest_published(self):
+    def test_window_is_twelve_calendar_months_ending_this_month(self):
+        # Anchored on today, NOT on the newest published month: a database
+        # whose latest map is old must still show a recent axis.
         meta = self.client.get(self.url()).json()["meta"]
-        self.assertEqual(meta["period"], "2026-05")
-        self.assertEqual(meta["from"], "2025-06")
-        self.assertEqual(meta["to"], "2026-05")
+        self.assertEqual(meta["from"], period_at(11))
+        self.assertEqual(meta["to"], period_at(0))
         self.assertEqual(meta["months"], 12)
+        # `period` is still the latest PUBLISHED month in that window.
+        self.assertEqual(meta["period"], period_at(LATEST))
 
     def test_history_pads_every_month_in_the_window(self):
         breakdown = self.client.get(self.url()).json()["breakdown"]
         self.assertEqual(breakdown["group"], "dclass_history")
         periods = [item["period"] for item in breakdown["data"]]
         self.assertEqual(len(periods), 12)
-        self.assertEqual(periods[0], "2025-06")
-        self.assertEqual(periods[-1], "2026-05")
+        self.assertEqual(periods[0], period_at(11))
+        self.assertEqual(periods[-1], period_at(0))
         self.assertEqual(periods, sorted(periods))
 
         by_period = {i["period"]: i["value"] for i in breakdown["data"]}
-        self.assertEqual(by_period["2025-12"], 3)
-        self.assertEqual(by_period["2026-05"], 4)
-        # never published -> null; published without a decision -> also null
-        self.assertIsNone(by_period["2025-06"])
-        self.assertIsNone(by_period["2026-02"])
-        self.assertIsNone(by_period["2026-03"])
+        self.assertEqual(by_period[period_at(7)], 3)
+        self.assertEqual(by_period[period_at(LATEST)], 4)
+        # never published -> null; published without a decision -> also null;
+        # the current month is not published yet -> also null
+        self.assertIsNone(by_period[period_at(11)])
+        self.assertIsNone(by_period[period_at(5)])
+        self.assertIsNone(by_period[period_at(4)])
+        self.assertIsNone(by_period[period_at(0)])
 
     def test_cards_carry_previous_month_and_signed_change(self):
         cards = self.client.get(self.url()).json()["data"]
@@ -75,9 +85,9 @@ class CDIExplorerStatsTestCase(CDIExplorerDataMixin, APITestCase):
         self.assertEqual(spi["value"], 0.05)
         self.assertEqual(spi["units"], "pct_rank")
         self.assertEqual(spi["label"], "SPI percentile rank")
-        self.assertEqual(spi["meta"]["period"], "2026-05")
+        self.assertEqual(spi["meta"]["period"], period_at(LATEST))
         self.assertEqual(spi["meta"]["previous"], 0.22)
-        self.assertEqual(spi["meta"]["previous_period"], "2026-04")
+        self.assertEqual(spi["meta"]["previous_period"], period_at(PREVIOUS))
         self.assertEqual(spi["meta"]["change_pct"], -77.3)
 
     def test_card_without_a_raster_reports_the_reason(self):
@@ -101,25 +111,31 @@ class CDIExplorerStatsTestCase(CDIExplorerDataMixin, APITestCase):
         )
 
     def test_unpublished_months_are_excluded(self):
+        # An in-review map for the CURRENT month must not become the latest
+        # period, and must not fill its strip cell.
         Publication.objects.create(
             cdi_geonode_id=9999,
-            year_month=date(2026, 6, 1),
-            due_date=date(2026, 7, 1),
+            year_month=month_start(period_at(0)),
+            due_date=month_start(period_at(0)),
             initial_values=[],
             validated_values=[
                 {"administration_id": MHLANGATANE, "value": 1, "category": 5}
             ],
             status=PublicationStatus.in_review,
         )
-        meta = self.client.get(self.url()).json()["meta"]
-        self.assertEqual(meta["period"], "2026-05")
+        data = self.client.get(self.url()).json()
+        self.assertEqual(data["meta"]["period"], period_at(LATEST))
+        by_period = {
+            i["period"]: i["value"] for i in data["breakdown"]["data"]
+        }
+        self.assertIsNone(by_period[period_at(0)])
 
     def test_unknown_administration_is_404(self):
         response = self.client.get(self.url(404404))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_query_count_is_bounded(self):
-        # 5 = administration, dclass, latest published, window, rasters.
+        # 5 = administration, dclass, published-exists, window, rasters.
         # Independent of window size — the guard against reintroducing an N+1.
         with self.assertNumQueries(5):
             self.client.get(self.url())
@@ -196,6 +212,64 @@ class CDIExplorerNoDataCategoryTestCase(APITestCase):
         history = {i["period"]: i["value"] for i in data["breakdown"]["data"]}
         self.assertEqual(history["2026-05"], -9999)
         self.assertEqual(data["value"]["dclass"]["category"], -9999)
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class CDIExplorerStalePublicationTestCase(APITestCase):
+    """The only published map is far older than the window.
+
+    This is a real environment: a database seeded with historical months, or a
+    long publication pause. Anchoring the window on the newest published month
+    made the strip render that month's year (e.g. 1999-2000) instead of the
+    last twelve; anchoring on today keeps the axis recent and shows the gap.
+    """
+
+    def setUp(self):
+        self.administration = Administration.objects.create(
+            pk=MHLANGATANE, name="Mhlangatane", region="Hhohho",
+            zone="highveld",
+        )
+        Publication.objects.create(
+            cdi_geonode_id=1,
+            year_month=date(2000, 2, 1),
+            due_date=date(2000, 3, 1),
+            initial_values=[],
+            validated_values=[
+                {"administration_id": MHLANGATANE, "value": 2, "category": 0}
+            ],
+            status=PublicationStatus.published,
+            published_at=timezone.now(),
+        )
+
+    def test_window_stays_recent_and_the_strip_is_empty(self):
+        data = self.client.get(
+            reverse(
+                "cdi-explorer-stats",
+                kwargs={
+                    "version": "v1",
+                    "administration_id": MHLANGATANE,
+                },
+            )
+        ).json()
+        self.assertEqual(data["meta"]["from"], period_at(11))
+        self.assertEqual(data["meta"]["to"], period_at(0))
+        # Nothing published inside it, so there is no "latest month" to date
+        # the cards by — and no card may claim a value.
+        self.assertIsNone(data["meta"]["period"])
+        self.assertIsNone(data["meta"]["last_updated"])
+        self.assertEqual(len(data["breakdown"]["data"]), 12)
+        self.assertTrue(
+            all(item["value"] is None for item in data["breakdown"]["data"])
+        )
+        for card in data["data"]:
+            self.assertIsNone(card["value"])
+            self.assertEqual(
+                card["meta"]["reason"], "no_published_data_in_window"
+            )
+        # The header chip still reports the last known class, whenever it was.
+        self.assertEqual(
+            data["value"]["dclass"], {"category": 0, "period": "2000-02"}
+        )
 
 
 class ChangePctTestCase(APITestCase):

--- a/backend/api/v1/v1_publication/urls.py
+++ b/backend/api/v1/v1_publication/urls.py
@@ -28,9 +28,26 @@ from .validation.view import (
     ValidationHistoryAPI,
 )
 from .twg.view import ReviewerAssignmentAPI
+from .insights.view import CDIExplorerStatsAPI, CDIExplorerSeriesAPI
 
 urlpatterns = [
     re_path(r"^(?P<version>(v1))/config.js", get_config_file),
+    # CDI Explorer (INS-3). Under /cdi/ rather than nested below
+    # /publications/ — the publication-details pattern further down has no
+    # trailing `$`, so anything nested under it is swallowed by a prefix
+    # match (same trap as D-3 and D-12 below). Anchored for the same reason.
+    re_path(
+        r"^(?P<version>(v1))/cdi/administrations/"
+        r"(?P<administration_id>[0-9]+)/stats$",
+        CDIExplorerStatsAPI.as_view(),
+        name="cdi-explorer-stats",
+    ),
+    re_path(
+        r"^(?P<version>(v1))/cdi/administrations/"
+        r"(?P<administration_id>[0-9]+)/series$",
+        CDIExplorerSeriesAPI.as_view(),
+        name="cdi-explorer-series",
+    ),
     re_path(
         r"^(?P<version>(v1))/reviewer/reviews",
         ReviewViewSet.as_view({"get": "list", "post": "create"}),

--- a/backend/api/v1/v1_publication/utils.py
+++ b/backend/api/v1/v1_publication/utils.py
@@ -22,15 +22,15 @@ def get_category(value: float):
     value = round(value, 3)
     if (value < 0):
         return DroughtCategory.none
-    if (value >= 0 and value <= 0.02):
+    if (value >= 0 and value <= 0.2):
         return DroughtCategory.d4
-    if (value > 0.02 and value <= 0.05):
+    if (value > 0.2 and value <= 0.5):
         return DroughtCategory.d3
-    if (value > 0.05 and value <= 0.1):
+    if (value > 0.5 and value <= 1.0):
         return DroughtCategory.d2
-    if (value > 0.1 and value <= 0.2):
+    if (value > 1.0 and value <= 2.0):
         return DroughtCategory.d1
-    if (value > 0.2 and value <= 0.3):
+    if (value > 2.0 and value <= 3.0):
         return DroughtCategory.d0
     return DroughtCategory.normal
 

--- a/backend/api/v1/v1_publication/validation/serializers.py
+++ b/backend/api/v1/v1_publication/validation/serializers.py
@@ -22,8 +22,11 @@ class ValidationMetaSerializer(serializers.Serializer):
     year_month = serializers.DateField(format="%Y-%m")
     published_at = serializers.DateTimeField()
     # Carried so re-opening the publish modal on an already-published map
-    # edits the live description instead of silently blanking it.
+    # edits the live description and bulletin link instead of silently
+    # blanking them — the modal submits both on every update, so a field it
+    # cannot prefill is a field it wipes.
     narrative = serializers.CharField(allow_null=True, allow_blank=True)
+    bulletin_url = serializers.CharField(allow_null=True, allow_blank=True)
     total = serializers.SerializerMethodField()
     reviewers_required = serializers.SerializerMethodField()
     can_publish = serializers.SerializerMethodField()

--- a/backend/api/v1/v1_publication/validation/serializers.py
+++ b/backend/api/v1/v1_publication/validation/serializers.py
@@ -21,6 +21,9 @@ class ValidationMetaSerializer(serializers.Serializer):
     publication_id = serializers.IntegerField(source="id")
     year_month = serializers.DateField(format="%Y-%m")
     published_at = serializers.DateTimeField()
+    # Carried so re-opening the publish modal on an already-published map
+    # edits the live description instead of silently blanking it.
+    narrative = serializers.CharField(allow_null=True, allow_blank=True)
     total = serializers.SerializerMethodField()
     reviewers_required = serializers.SerializerMethodField()
     can_publish = serializers.SerializerMethodField()

--- a/backend/api/v1/v1_publication/views.py
+++ b/backend/api/v1/v1_publication/views.py
@@ -567,7 +567,13 @@ class PublicationViewSet(viewsets.ModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = Publication.objects.all().order_by("-due_date")
+        # Newest month first. Ordering by -due_date instead put an older month
+        # on top: due dates repeat across publications (a batch created
+        # together shares one), and ties in the sort column are returned in
+        # whatever order the database chooses. `-id` breaks any remaining tie
+        # so the page is stable across requests and paginates without
+        # dropping or repeating rows.
+        queryset = Publication.objects.all().order_by("-year_month", "-id")
         params = self.request.query_params
         status_filter = params.get("status")
         if status_filter == FilterStatus.not_yet_started:

--- a/backend/api/v1/v1_weather/services.py
+++ b/backend/api/v1/v1_weather/services.py
@@ -28,6 +28,11 @@ from api.v1.v1_weather.topo import (
     assign_region,
     haversine_km,
 )
+# Drought class is owned by v1_publication (INS-3 D-6): every Detailed
+# Insights tab renders the same chip, so the rule has one definition, beside
+# the model it reads. No cycle — v1_publication never imports v1_weather.
+from api.v1.v1_publication.insights.utils import current_dclass
+from utils.periods import month_range
 
 logger = logging.getLogger(__name__)
 
@@ -126,17 +131,6 @@ def station_health(station, today=None) -> dict:
         "last_reading": last_reading.isoformat(),
         "completeness_30d": completeness,
     }
-
-
-def month_range(from_period: str, to_period: str) -> list:
-    """Inclusive list of 'YYYY-MM' periods."""
-    year, month = map(int, from_period.split("-"))
-    end_year, end_month = map(int, to_period.split("-"))
-    periods = []
-    while (year, month) <= (end_year, end_month):
-        periods.append(f"{year:04d}-{month:02d}")
-        year, month = (year, month + 1) if month < 12 else (year + 1, 1)
-    return periods
 
 
 def monthly_series(
@@ -319,39 +313,6 @@ def resolve_administration_latest(administration) -> dict:
     }
 
 
-def _current_dclass(administration):
-    """Drought class from the latest PUBLISHED publication's
-    validated_values; None when no published month covers this
-    administration. Labels/colors stay in frontend config (CLAUDE.md)."""
-    from api.v1.v1_publication.constants import PublicationStatus
-    from api.v1.v1_publication.models import Publication
-
-    publication = (
-        Publication.objects.filter(
-            status=PublicationStatus.published,
-            validated_values__isnull=False,
-        )
-        .order_by("-year_month")
-        .first()
-    )
-    if not publication:
-        return None
-    item = next(
-        (
-            i
-            for i in (publication.validated_values or [])
-            if i.get("administration_id") == administration.pk
-        ),
-        None,
-    )
-    if not item or item.get("category") is None:
-        return None
-    return {
-        "category": item["category"],
-        "period": publication.year_month.strftime("%Y-%m"),
-    }
-
-
 def _resolve_station_with_data(administration):
     """First D-5 candidate that has any ingested data."""
     for candidate, resolution, distance_km in _resolution_candidates(
@@ -371,7 +332,7 @@ def _administration_base(administration, with_context=False) -> dict:
     if with_context:
         base["value"] = {
             "zone": administration.zone,
-            "dclass": _current_dclass(administration),
+            "dclass": current_dclass(administration),
         }
     return base
 

--- a/backend/utils/periods.py
+++ b/backend/utils/periods.py
@@ -1,0 +1,36 @@
+"""Calendar-month period helpers — periods are 'YYYY-MM' strings.
+
+Shared rather than per-app because the explorer tabs pad their chart axes the
+same way: every month in the requested window is emitted, gaps carrying null,
+so a missing month reads as a gap instead of shifting the axis. `month_range`
+started in v1_weather; v1_publication needs the same thing, and calendar
+arithmetic belongs to neither app.
+"""
+from datetime import date, datetime
+
+
+def month_start(period: str) -> date:
+    """'YYYY-MM' -> the first of that month, for ORM date filters."""
+    return datetime.strptime(f"{period}-01", "%Y-%m-%d").date()
+
+
+def shift_period(period: str, months: int) -> str:
+    """'2026-05' shifted by N months, N negative to go back."""
+    year, month = map(int, period.split("-"))
+    total = year * 12 + month - 1 + months
+    return f"{total // 12:04d}-{total % 12 + 1:02d}"
+
+
+def period_span(from_period: str, to_period: str) -> int:
+    """Months in the inclusive window; zero or negative when reversed."""
+    from_year, from_month = map(int, from_period.split("-"))
+    to_year, to_month = map(int, to_period.split("-"))
+    return (to_year - from_year) * 12 + to_month - from_month + 1
+
+
+def month_range(from_period: str, to_period: str) -> list:
+    """Inclusive list of 'YYYY-MM' periods; empty when reversed."""
+    return [
+        shift_period(from_period, offset)
+        for offset in range(max(period_span(from_period, to_period), 0))
+    ]

--- a/eswatini-v2/docs/track-3/cdi-explorer-backend-api.md
+++ b/eswatini-v2/docs/track-3/cdi-explorer-backend-api.md
@@ -1,0 +1,721 @@
+# Feature Design Document
+
+## Feature: Backend — CDI Explorer API (`v1_publication`)
+
+**Task ID**: INS-3 (INS-1 = insights shell + first CDI tab, frontend-only; INS-2 = national overview)
+**Author**: Iwan Firmawan (with Claude)
+**Date**: 2026-07-27
+**Status**: Implemented (2026-07-27) — 25 new tests; full backend suite (651)
+green after the `current_dclass` and `month_range` moves
+**Figma**: [Detailed insights → CDI Explorer, node `3483-57786`](https://www.figma.com/design/gtNfp5n7NawbYW5u8cPrpT/Eswatini-Drought-platform?node-id=3483-57786&m=dev)
+**Builds on**: [`publication-raster-extraction.md`](publication-raster-extraction.md) (PublicationRaster, implemented) · [`weather-explorer-public-api.md`](weather-explorer-public-api.md) (WX-4 — the contract shape this mirrors) · supersedes the backend half of [`../specs/INS-1_insights_cdi_explorer.md`](../specs/INS-1_insights_cdi_explorer.md)
+
+---
+
+## 1. Context & Problem Statement
+
+```
+Currently:
+- INS-1 shipped the CDI explorer as a FRONTEND-ONLY tab: it assembles a
+  12-month D-class history client-side from GET /dates plus one GET /map/{id}
+  per month (INS-1 D-2). That is 13 round trips per Inkhundla view, each one
+  transferring all 59 Tinkhundla to use a single row.
+- INS-1 predates PublicationRaster. The component indicator values it promised
+  as "indicator toggles (LST/NDVI/SPI/SM)" were never wired to a real source —
+  it pointed at a WX-1 aggregate endpoint that serves STATION observations,
+  not the satellite indices the CDI is composed from.
+- PublicationRaster (implemented) now holds per-Inkhundla zonal values for
+  esi/evi2/sm/spi, one row per publication+indicator, extracted automatically
+  at publication create time. NOTHING reads it on the public surface.
+- The redesigned Figma frame needs four things per Inkhundla that no endpoint
+  serves: a 12-cell D-class strip, four "last month" metric cards with a
+  previous-month delta, and four independently date-filtered monthly charts.
+
+Goal:
+- Two read endpoints in v1_publication that serve the whole CDI Explorer tab
+  per Inkhundla, from data already in the database, with no new models and no
+  new extraction pipeline.
+```
+
+### 1.1 The chart titles keep the Figma wording; the served index differs — CONFIRMED 2026-07-27
+
+The Figma chart titles name upstream products the CDI pipeline does not use.
+**The display text stays as designed** (product decision 2026-07-27 — "LST"
+and "NDVI" are the words the TWG audience reads); the index actually served
+under each title is the one the pipeline produces and the hub already
+extracts:
+
+| Figma chart title (kept) | Index actually served | Pipeline source | Stored as |
+|---|---|---|---|
+| Monthly precipitation average (CHIRPS) | **SPI 3-month** | `chirps_spi_3mn` | `PublicationRaster.indicator = "spi"` |
+| Monthly vegetation greenness (NDVI) | **EVI2** — Enhanced Vegetation Index 2 | `evi2_1mn` | `…indicator = "evi2"` |
+| Monthly Land surface temperature (LST) | **ESI** — Evaporative Stress Index | `era5_esi_1mn` | `…indicator = "esi"` |
+| Monthly soil moisture (SMAP) | **NOAH soil moisture** | `noah_soilm_1mn` | `…indicator = "sm"` |
+
+The API speaks only in the four index keys and their existing `FieldStr`
+names — `label` is `"ESI percentile rank"`, not the chart title. **The Figma
+titles live in the frontend**, keyed off `key`, per the CLAUDE.md rule that
+derived display copy never comes from the API. The upstream product names
+(`era5_esi_1mn`, …) are documentation too: they are recorded in the
+`RasterIndicatorTypes` docstring and in this table, not shipped on every
+response — `indicator` already identifies the index.
+
+Titles are settled; **units are not**. Two things in the design file are still
+wrong and are frontend work:
+
+- **All four series are percentile ranks on a common 0–1 scale**, per
+  [`publication-raster-extraction.md`](publication-raster-extraction.md) D-4
+  (the `STEP_0303_*_pct_rank` GeoTIFFs). There is no `mm`, no `°C`, no
+  `m³/m³` in this feature — the API reports `units: "pct_rank"` on every
+  series and card.
+- So the Figma subtitles (`mm / month`, `Degrees °C`, `m³/m³`), the y-axes
+  (`0–3k`, `25°–37°`) and the metric-card values (`5 mm`, `32 °C`) are
+  placeholder copy. Every axis becomes `0–1`; every card reads a rank.
+
+Frontend copy per chart — the title is the design's, the subtitle is where the
+real index surfaces to the reader (and `label` from the API says the same
+thing):
+
+| key | title (frontend copy) | subtitle (frontend) | `label` (from API) |
+|---|---|---|---|
+| `spi` | Monthly precipitation average (CHIRPS) | SPI 3-month percentile rank · 0–1 | SPI percentile rank |
+| `evi2` | Monthly vegetation greenness (NDVI) | EVI2 percentile rank · 0–1 | EVI2 percentile rank |
+| `esi` | Monthly land surface temperature (LST) | ESI percentile rank · 0–1 | ESI percentile rank |
+| `sm` | Monthly soil moisture (SMAP) | NOAH soil moisture percentile rank · 0–1 | SM percentile rank |
+
+---
+
+## 2. Requirements
+
+### User Acceptance Criteria
+- [x] Selecting an Inkhundla shows its name, region · zone and current
+      published drought-class chip — identical data to the sibling explorer
+      tabs, so the shared `InkhundlaHeader` component keeps working unchanged.
+- [x] A 12-cell **D-class classification history** strip renders one cell per
+      published month, oldest → newest, with months that have no published
+      decision rendered as "No data" rather than shifting the axis.
+- [x] Four **metric cards** show last month's value per index, the previous
+      month's value, and the signed change between them.
+- [x] Four **monthly charts** render the same four indices over a date range,
+      each chart's range picker refetching only its own series.
+- [x] An Inkhundla with no published publication at all still renders the
+      header and returns an explicit empty-state reason, not a 500 or an
+      empty chart.
+
+### Technical Acceptance Criteria
+- [x] No new model, no migration. Served entirely from `Publication`,
+      `PublicationRaster` and `Administration`.
+- [x] One request replaces INS-1's 13; the 12-month strip and all four card
+      values come from a single `/stats` call.
+- [x] Public (`AllowAny`), DB-reads-only, no GeoNode call on the read path.
+- [x] Generic contract keys (`key`/`label`/`value`/`data`/`group`/`period`/
+      `meta`/`breakdown`) per CLAUDE.md; no drought labels or colors in any
+      payload — those stay in `frontend/src/static/config.js`.
+- [x] Bounded query cost — 5 queries for `/stats`, 4 for `/series`,
+      **independent of window size** (administration, current D-class, latest
+      published month, the window, the rasters), with an explicit max span so
+      a crafted `from`/`to` cannot scan the table.
+- [x] Tests in `api/v1/v1_publication/tests/tests_cdi_explorer_*.py` on a
+      shared mixin, covering the empty states and the range validation.
+
+---
+
+## 3. Data Model Changes
+
+### New Models
+
+**None.** This is the headline of the design — every value the Figma frame
+needs is already in the database:
+
+| Figma element | Source |
+|---|---|
+| Inkhundla name · region · zone | `Administration.name` / `.region` / `.zone` |
+| Current drought chip | latest `status=published` `Publication.validated_values[].category` |
+| D-class history strip | the same field across the published months in the window |
+| 4 metric cards | `PublicationRaster.values[]` for the last two published months |
+| 4 monthly charts | `PublicationRaster.values[]` across the window |
+| "Last updated" (page header) | `Publication.published_at` of the latest published month |
+
+### Modified Models
+
+| Model | Change | Reason |
+|-------|--------|--------|
+| — | none | no migration in this feature |
+
+### Constants (not a migration)
+
+`api/v1/v1_publication/constants.py`:
+
+```python
+class RasterIndicatorTypes:
+    """The CDI component indices extracted per publication.
+
+    Upstream (confirmed with the CDI pipeline 2026-07-27): esi=era5_esi_1mn,
+    evi2=evi2_1mn, sm=noah_soilm_1mn, spi=chirps_spi_3mn. The CDI explorer
+    charts these under titles naming DIFFERENT products ("LST", "NDVI",
+    "SMAP") — that copy is the frontend's; the API only ever speaks in these
+    four keys and their FieldStr names.
+    """
+    # ... existing esi/evi2/sm/spi, FieldStr and choices() unchanged ...
+
+
+# Every extracted index is a percentile rank on a common 0-1 scale
+# (publication-raster-extraction.md D-4), so one unit token covers all four.
+PCT_RANK_UNITS = "pct_rank"
+
+# Explorer window bounds. 12 = the Figma strip; 120 caps a crafted from/to so
+# it cannot walk the whole publication history.
+CDI_EXPLORER_DEFAULT_MONTHS = 12
+CDI_EXPLORER_MAX_MONTHS = 120
+```
+
+`RasterIndicatorTypes.FieldStr` is **unchanged and reused as the contract's
+`label`**. No title map and no source map live in the backend: chart titles
+are frontend copy (CLAUDE.md), and the upstream product names are provenance
+for a reader, so they sit in the docstring rather than on every response —
+`indicator` already identifies the index.
+
+Metric-card titles ("Last month's temperature", …) are shorter than the chart
+titles in the design. Also UI copy: the API returns one `label` per index and
+the cards render their own heading.
+
+### Shared helper (`backend/utils/`)
+
+`month_range()` — the inclusive `YYYY-MM` list both explorer tabs pad their
+axes with — already existed in `v1_weather/services.py`. It moves to a new
+`utils/periods.py` alongside `month_start()`, `shift_period()` and
+`period_span()`, and `v1_weather` imports it from there. Calendar arithmetic
+belongs to neither app, and INS-3 needed the same thing.
+
+### Migration Strategy
+
+```python
+# No migration. Constants-only change; existing rows untouched; nothing to
+# roll back beyond reverting the module.
+```
+
+---
+
+## 4. API Contract
+
+Both endpoints live in a new `api/v1/v1_publication/insights/` subpackage
+(`view.py` / `serializers.py` / `utils.py`), matching the existing
+`review/`, `validation/` and `twg/` subpackages and the 200–400-line file rule.
+
+### Endpoints
+
+| Method | URL | Purpose | Auth |
+|--------|-----|---------|------|
+| GET | `/api/v1/cdi/administrations/<administration_id>/stats` | Header context + D-class history strip + 4 metric cards | Public |
+| GET | `/api/v1/cdi/administrations/<administration_id>/series?indicators=&from=&to=` | The 4 chart series (or a subset) | Public |
+
+> **Export CSV is out of scope** (product, 2026-07-27). The button in the
+> "Explore insights" header is not served by this feature.
+
+Query parameters (validated by a DRF serializer with `raise_exception=True`,
+so DRF renders the 400 — house style):
+
+| Param | Endpoint | Format | Default |
+|---|---|---|---|
+| `from` | series | `YYYY-MM`, inclusive | latest published month − 11 |
+| `to` | series | `YYYY-MM`, inclusive | latest published month |
+| `indicators` | series | comma-separated subset of `spi,evi2,esi,sm` | all four |
+
+Invalid month format, `from > to`, span > `CDI_EXPLORER_MAX_MONTHS`, or an
+unknown indicator key → `400`. Unknown `administration_id` → `404` via
+`get_object_or_404`.
+
+### `/stats` response
+
+```json
+{
+  "key": 4588078,
+  "label": "Mhlangatane",
+  "group": "Hhohho",
+  "value": {
+    "zone": "highveld",
+    "dclass": {"category": 4, "period": "2026-05"}
+  },
+  "data": [
+    {"key": "spi", "label": "SPI percentile rank",
+     "value": 0.05, "units": "pct_rank",
+     "meta": {"period": "2026-05", "previous": 0.22,
+              "previous_period": "2026-04", "change_pct": -77.3}},
+    {"key": "evi2", "label": "EVI2 percentile rank",
+     "value": 0.26, "units": "pct_rank",
+     "meta": {"period": "2026-05", "previous": 0.50,
+              "previous_period": "2026-04", "change_pct": -48.0}},
+    {"key": "esi", "label": "ESI percentile rank",
+     "value": null, "units": "pct_rank",
+     "meta": {"period": "2026-05", "previous": null,
+              "previous_period": null, "change_pct": null,
+              "reason": "no_raster_data"}},
+    {"key": "sm", "label": "SM percentile rank",
+     "value": 0.05, "units": "pct_rank",
+     "meta": {"period": "2026-05", "previous": 0.22,
+              "previous_period": "2026-04", "change_pct": -77.3}}
+  ],
+  "breakdown": {
+    "group": "dclass_history",
+    "data": [
+      {"period": "2025-06", "value": 3},
+      {"period": "2025-07", "value": 5},
+      {"period": "2025-08", "value": null},
+      {"period": "2026-05", "value": 4}
+    ]
+  },
+  "meta": {
+    "period": "2026-05",
+    "last_updated": "2026-05-15T06:12:00Z",
+    "from": "2025-06", "to": "2026-05", "months": 12
+  }
+}
+```
+
+- `breakdown.data[].value` is the raw `category` int from
+  `validated_values` (0–5); `null` = the month is published but carries no
+  decision for this Inkhundla, **or** no publication exists for that month.
+  `-9999` (`DroughtCategory.none`) is passed through untouched — the frontend
+  already maps it to the "No data" chip in `InkhundlaHeader`.
+- Every month in the window is present, so the 12-cell strip never shifts.
+- `change_pct` is signed and rounded to 1dp; `null` when the previous month
+  has no value or is `0` (no meaningful ratio). **The frontend derives the
+  arrow direction from the sign** — the Figma mock shows an up-arrow on
+  `5 mm ← prev 34 mm`, which is a mock inconsistency, not a rule.
+- The cards render **the actual period, not the words "Last month's …"**
+  (confirmed 2026-07-27). Publication lag puts the latest published month
+  1–2 months behind the calendar, so each card's subtitle formats
+  `meta.period` (and `meta.previous_period` for the delta row) — the same
+  thing `WeatherTab` already does with `monthLabel(card.meta.period)`.
+- No published publication exists **at all** →
+  `"data": null, "breakdown": null, "meta": {"reason": "no_published_data"}`;
+  the header block (`key`/`label`/`group`/`value.zone`) is still returned so
+  the page renders. Same convention as WX-4's `no_station_data_for_period`.
+  An Inkhundla that simply never appears in any published month is *not* this
+  case — it gets the full window with `null` throughout, since the page can
+  still show which months were published.
+- An index with no extracted raster in the window →
+  `"value": null` + `"meta": {"reason": "no_raster_data"}` on that card only.
+
+### `/series` response
+
+```json
+{
+  "key": 4588078, "label": "Mhlangatane", "group": "Hhohho",
+  "data": [
+    {"key": "spi", "label": "SPI percentile rank", "units": "pct_rank",
+     "data": [{"period": "2025-06", "value": 0.41},
+              {"period": "2025-07", "value": null},
+              {"period": "2025-08", "value": 0.38}]},
+    {"key": "evi2", "label": "EVI2 percentile rank", "units": "pct_rank",
+     "data": [{"period": "2025-06", "value": 0.62}]}
+  ],
+  "meta": {"from": "2025-06", "to": "2026-05", "months": 12,
+           "indicators": ["spi", "evi2", "esi", "sm"]}
+}
+```
+
+Every month in the window appears in every series, `value: null` for gaps —
+so a chart's x-axis is honest about missing months instead of compressing
+them. Same rule WX-4 settled on.
+
+Each Figma chart owns its own date picker, so the frontend fetches
+`?indicators=spi&from=…&to=…` for a single-chart refetch and the unfiltered
+form once on mount.
+
+### Read path (both endpoints)
+
+```python
+# 1. Window: the published months, ascending. Periods are 'YYYY-MM' strings
+# throughout (utils/periods.py); month_start() converts for the ORM filter.
+publications = Publication.objects.filter(
+    status=PublicationStatus.published,
+    published_at__isnull=False,
+    year_month__range=(
+        month_start(from_period), month_start(to_period)
+    ),
+).order_by("year_month")
+
+# 2. Indicator values for those months, in one query.
+# ponytail: values is a ~59-item JSON blob scanned in Python. Worst case here
+# is 4 indicators x 120 months = 480 blobs, still trivial. Ceiling: a
+# national view (all 59 Tinkhundla at once) would scan 59x this per request —
+# that is when a publication_raster_values table earns its migration.
+rasters = PublicationRaster.objects.filter(
+    publication__in=publications, indicator__in=indicators
+).values_list("publication__year_month", "indicator", "values")
+```
+
+Five queries for `/stats` and four for `/series` — administration, current
+D-class, latest published month, the window, the rasters — all independent of
+window size. No GeoNode call, no N+1. (`current_dclass` keeps its own query
+rather than reusing `latest`: it filters on `validated_values`, not
+`published_at`, and matching WX-4's existing behaviour exactly is worth more
+than saving one indexed lookup.)
+
+---
+
+## 5. Decision Log
+
+### D-1: Real endpoints, not INS-1's client-side assembly
+
+**Options Considered**:
+1. Keep INS-1 D-2: frontend fans out `/dates` + one `/map/{id}` per month.
+2. Two server endpoints keyed by `administration_id`.
+
+**Decision**: Option 2.
+
+**Rationale**: INS-1's approach costs 13 round trips per Inkhundla and
+downloads all 59 Tinkhundla's values 12 times to read one row each time —
+~700 discarded records per page view. It also cannot serve the indicator
+series at all: `/map/{id}` exposes `validated_values` only, and
+`PublicationRaster` (which did not exist when INS-1 was written) is reachable
+from no public endpoint. The redesigned frame needs both.
+
+**Impact**: INS-1's D-2 stands as the *source of truth* statement (published
+`validated_values` is still where D-class comes from); only its transport
+decision is superseded. The frontend tab drops its `/dates` + `/map` fan-out.
+
+### D-2: `/stats` + `/series` split, mirroring WX-4
+
+**Options Considered**:
+1. One composite endpoint returning header, strip, cards and charts.
+2. Split: `/stats` (range-independent) and `/series` (range-dependent).
+
+**Decision**: Option 2.
+
+**Rationale**: identical to WX-4 D-2, and stronger here — this frame has
+**four independent date pickers**, one per chart. A composite endpoint would
+re-serve the header, the 12-cell strip and all four cards on every picker
+drag. The split also lets `/series` take an `indicators` filter so a single
+chart's refetch transfers one series instead of four.
+
+**Impact**: two view classes; the frontend tab issues one `/stats` on mount
+and one `/series` per picker interaction.
+
+### D-3: Served from `PublicationRaster.values` JSON — no new table
+
+**Options Considered**:
+1. Denormalise into a `publication_raster_values` row-per-(publication,
+   indicator, administration) table for indexed reads.
+2. Read the existing JSON blobs and pluck in Python.
+
+**Decision**: Option 2.
+
+**Rationale**: the per-Inkhundla explorer reads at most
+`indicators × months` blobs (48 at the default window, 480 at the 120-month
+ceiling). A migration plus a dual-write path to make that faster is work
+without a measurable problem to solve. This mirrors the standing decision on
+`Review.suggestion_values`: keep the JSON until a cross-publication analytical
+query actually needs the table.
+
+**Impact**: the ceiling is documented in the read path above. The trigger to
+revisit is a **national** view (all 59 Tinkhundla in one response), not a
+longer window.
+
+### D-4: Published-only, for both the strip and the series
+
+**Options Considered**:
+1. Include `in_review` / `in_validation` months so the newest data appears
+   immediately.
+2. `status=published` and `published_at__isnull=False` only.
+
+**Decision**: Option 2.
+
+**Rationale**: this is a public, anonymous-readable surface. Component rasters
+are extracted at publication *create* time, so an unpublished month already
+has indicator values sitting in `PublicationRaster` — serving them would leak
+a month that is still under TWG review, and the four charts would silently run
+one month ahead of the D-class strip beside them.
+
+**Impact**: the strip, the cards and the charts always share one window and
+one "latest month". `meta.period` is that month everywhere on the page.
+
+### D-5: The API speaks in indices only; the designed titles live in the frontend
+
+**Options Considered**:
+1. Key the contract on the Figma slot names (`precipitation_monthly`,
+   `temperature_monthly`, …) and serve whatever index backs each slot.
+2. Key on the actual index (`spi`/`evi2`/`esi`/`sm`) *and* rewrite the chart
+   titles to the index names.
+3. Key on the actual index, ship the designed title as `label`, and report
+   the real index + upstream product in `meta`.
+4. Key on the actual index, `label` = the existing `FieldStr` index name, and
+   keep both the titles and the product names out of the payload.
+
+**Decision**: Option 4. (Option 3 was the drafted design; the title map and
+source map were dropped during implementation review.)
+
+**Rationale**: the *key* must be the index, because it is the
+`PublicationRaster.indicator` value the query filters on — an intent-named key
+like `temperature_monthly` would need a translation table on both sides and
+would make `?indicators=` unmappable to the model field. That settles Option 1.
+
+Between 2, 3 and 4: "LST" and "NDVI" stay as the words on the page (product,
+2026-07-27), so Option 2 is out. Option 3 then put those titles in the backend
+as a `DISPLAY_LABELS` map — but chart titles are exactly the derived display
+copy CLAUDE.md keeps in `static/config.js`, and a `SOURCES` map buys nothing
+either: `indicator` already identifies the index, so the upstream product name
+is provenance for a human reader, not a field a client branches on. Both maps
+were deleted; the product names moved to the `RasterIndicatorTypes` docstring.
+
+**Impact**: `label` is the existing `FieldStr` value — **no new constant, and
+no `meta.index` / `meta.source`**. The frontend owns the key → title mapping.
+`units` stays `pct_rank` and does **not** follow the title, so the design file
+still needs its subtitles and y-axes corrected (§1.1). If the pipeline ever
+adds true physical-unit rasters they arrive as *new* `RasterIndicatorTypes`
+entries alongside these — no contract change.
+
+### D-6: `current_dclass` moves to `v1_publication`; `v1_weather` imports it
+
+**Options Considered**:
+1. Copy `v1_weather.services._current_dclass` into the new insights package.
+2. Import it from `v1_weather` into `v1_publication`.
+3. Move it to `v1_publication/insights/utils.py` and have `v1_weather` import it.
+
+**Decision**: Option 3.
+
+**Rationale**: the helper reads `Publication` and `PublicationStatus` and
+already does a deferred in-function import back into `v1_publication` to avoid
+a cycle — a tell that it is living in the wrong app. Option 1 duplicates the
+"what is this Inkhundla's current D-class" rule across two apps, which is
+exactly the definition that must never drift between the explorer tabs.
+Option 2 makes `v1_publication` depend on `v1_weather`, backwards.
+
+**Impact**: `v1_weather.services._current_dclass` is **deleted**, not wrapped.
+Its deferred in-function import was there to dodge a cycle that does not
+exist — `v1_publication` imports nothing from `v1_weather` — so the import
+moves to the module top, and with one caller (`_administration_base`) the
+wrapper was pure indirection. The existing WX-4 stats tests are the parity
+check; they pass untouched.
+
+### D-7: Public (`AllowAny`)
+
+**Options Considered**:
+1. JWT-required, since Detailed Insights sits under Track 3 (operational).
+2. `AllowAny`, matching the sibling explorer tabs.
+
+**Decision**: Option 2.
+
+**Rationale**: the Weather Station Explorer (WX-4) and IKS Explorer tabs on
+the *same page* are already public; a CDI tab that 401s on the same page
+would be an inconsistency the user experiences as a bug. Everything served
+here is derived from **published** maps (D-4) — data that is already public
+via `/maps`, `/map/{id}` and the exports.
+
+**Impact**: no per-field auth gating anywhere in this contract — there is no
+CDI equivalent of WX-4's TWG-only completeness card.
+
+### D-8: Cards return a signed change; the frontend renders direction
+
+**Options Considered**:
+1. Return `direction: "up" | "down"` plus an absolute change.
+2. Return a signed `change_pct` and let the UI derive the arrow.
+
+**Decision**: Option 2.
+
+**Rationale**: arrow glyph and color are derived UI config, which CLAUDE.md
+keeps out of API responses. It also avoids re-encoding the Figma mock's own
+inconsistency (an up-arrow on `5 mm` vs `prev 34 mm`).
+
+**Impact**: `change_pct` is `null`, not `0`, when the previous month is
+missing or zero — the card then shows the value with no delta row rather than
+claiming "no change".
+
+### D-9: New `insights/` subpackage inside `v1_publication`
+
+**Options Considered**:
+1. Append to `views.py` (already 1265 lines) and `serializers.py` (614).
+2. A new `v1_publication/insights/` subpackage.
+3. A new Django app, `v1_insights`.
+
+**Decision**: Option 2.
+
+**Rationale**: `views.py` is already past the 400-line guideline and this adds
+two views plus the window/pluck helpers. The app already established the
+subpackage pattern (`review/`, `validation/`, `twg/` — each `view.py`,
+`serializers.py`, `utils.py`), so this is the existing shape, not a new one.
+A separate app would need its own migrations dir and models module for zero
+models, and would put the reader in a different app from `PublicationRaster`.
+
+**Impact**: `urls.py` gains two `re_path` entries importing from
+`.insights.view`.
+
+### D-10: URL prefix `/cdi/administrations/<id>/…`
+
+**Options Considered**:
+1. `/publications/administrations/<id>/cdi/stats` (nested under the app's
+   existing `/publications/` prefix).
+2. `/cdi/administrations/<id>/stats` (parallel to `/weather/administrations/…`).
+
+**Decision**: Option 2.
+
+**Rationale**: the three explorer tabs should read alike —
+`/weather/administrations/<id>/stats` exists, `/iks/<id>/stats` exists, so
+`/cdi/administrations/<id>/stats` completes the set with the newer of the two
+conventions (explicit `administrations` segment). More importantly,
+`v1_publication/urls.py` already carries two hard-won warnings (D-3 and D-12
+in that file) that its unanchored `/admin/publication/(?P<pk>[0-9]+)` pattern
+**swallows anything nested below it** — nesting a new tree under
+`/publications/` invites the same trap.
+
+**Impact**: both new patterns are anchored with a trailing `$` and are
+registered *above* the unanchored publication patterns.
+
+### D-11: Same fetch convention as the existing tabs; different default window
+
+**Options Considered**:
+1. Copy WX-4 wholesale, including its default window (current calendar year
+   to date).
+2. Copy the *mechanism* and set the default to the last 12 published months.
+3. Fix the window to an agricultural/financial year boundary.
+
+**Decision**: Option 2 (asked and answered 2026-07-27 — "do the same as
+`frontend/src/app/detailed-insights/`").
+
+**Rationale**: the mechanism is already settled by `useWeatherSeries` and
+should be copied exactly — one hook call **per chart**, `{from, to}` held as
+`"YYYY-MM"` strings because that is the shape `/series` takes, and **omitted
+entirely on first load so the backend owns the default**. A CDI hook is that
+hook plus an `indicators` param (D-2).
+
+The default *value* is where this tab must diverge, and the reason is
+concrete: weather can use calendar-year-to-date because the WIS2 archive is
+daily and current, but CDI publishes with a 1–2 month lag. Calendar-YTD in
+July would return four published months and seven empty ones, while the strip
+beside the charts is specified as 12 filled cells. "The last 12 **published**
+months, ascending" makes the strip, the cards and the charts share one window
+and one latest month.
+
+Option 3 was checked and rejected: the Figma subtitle ("Jun '25 → May '26")
+disagrees with its own cell labels (Jul 2025 → Jun 2026), which reads as mock
+drift rather than an intended year boundary, and no agricultural-year
+requirement exists anywhere else in the product.
+
+**Impact**: `CDI_EXPLORER_DEFAULT_MONTHS = 12` anchored on the latest
+published month, not on `today`. The frontend adds `useCdiSeries` mirroring
+`useWeatherSeries` — including its in-flight `cancelled` guard, which a
+four-picker page needs more than the two-picker weather tab does.
+
+---
+
+## 6. Type/Constant Mappings
+
+| Figma / frontend | Backend constant | API value |
+|---|---|---|
+| "Monthly precipitation average" chart | `RasterIndicatorTypes.spi` | `"spi"` |
+| "Monthly vegetation greenness" chart | `RasterIndicatorTypes.evi2` | `"evi2"` |
+| "Monthly land surface temperature" chart | `RasterIndicatorTypes.esi` | `"esi"` |
+| "Monthly soil moisture" chart | `RasterIndicatorTypes.sm` | `"sm"` |
+| all four y-axis units | `PCT_RANK_UNITS` | `"pct_rank"` |
+| D0 … D4 chips on the strip | `DroughtCategory.d0 … d4` | `1 … 5` |
+| "Normal" chip | `DroughtCategory.normal` | `0` |
+| "No data" cell | `DroughtCategory.none` / absent month | `-9999` / `null` |
+| chip label + color | `DROUGHT_CATEGORY_LABEL` / `_COLOR` (`static/config.js`) | **not in the API** |
+| strip length | `CDI_EXPLORER_DEFAULT_MONTHS` | 12 |
+| max range span | `CDI_EXPLORER_MAX_MONTHS` | 120 |
+
+---
+
+## 7. Compatibility & Migration
+
+### Backward Compatibility
+- [x] Existing API consumers unaffected — two additive endpoints, no change
+      to `/maps`, `/map/{id}`, `/dates` or the raster endpoints.
+- [x] Existing data preserved — no migration.
+- [x] CLI tools still work — no seeder, job or management command touched.
+- [x] `InkhundlaHeader` (already shared by the Weather and IKS tabs) consumes
+      `label` / `group` / `value.zone` / `value.dclass.category` unchanged.
+- [ ] **INS-1's frontend CDI tab is superseded** — its `/dates` + `/map/{id}`
+      fan-out is replaced by `/stats`. Frontend work, tracked separately.
+
+### Seeder/CLI Compatibility
+- [x] Existing seeders work — `publications_seeder` (with rasters) already
+      produces everything these endpoints read.
+- [x] No new seeder command needed. A local dev database needs ≥2 published
+      months **with component rasters extracted** for the cards to show a
+      delta; the existing seeder covers that.
+
+---
+
+## 8. Security Considerations
+
+- [x] **Permission model**: `AllowAny` on both (D-7). Everything derived
+      from published publications only (D-4) — no `in_review` or
+      `in_validation` data, no reviewer identity, no validation reasoning, no
+      `ValidationDecision` field is reachable through this contract.
+- [x] **Input validation**: `administration_id` via `get_object_or_404`;
+      `from`/`to`/`indicators` via a DRF serializer with
+      `raise_exception=True`. `indicators` is validated against
+      `RasterIndicatorTypes` — the value reaches the ORM only as a
+      `indicator__in` list of known constants, never as raw input.
+- [x] **No new attack vectors**: the range span is capped at
+      `CDI_EXPLORER_MAX_MONTHS`, so `from=1900-01&to=2999-12` — and
+      `from=1900-01` alone against the default `to` — are 400s rather than a
+      full-table scan; queries are bounded at 5 per request regardless of
+      window; no outbound GeoNode call on the read path, so an upstream
+      outage or a slow response cannot be induced from here.
+- [x] **No file/CSV surface**: export is out of scope (§4), so this feature
+      adds no download path and no formula-injection surface.
+
+---
+
+## 9. Testing Strategy
+
+| Test Type | Coverage |
+|-----------|----------|
+| Unit | Window resolution (default = latest published month − 11; `from`/`to` override; span cap). `change_pct` sign, 1dp rounding, and the `null` cases (previous missing / previous `0`). Category pass-through for `-9999`. `current_dclass` parity after the D-6 move — the existing WX-4 stats tests must pass untouched. |
+| Integration | `/stats`: full payload for an Inkhundla with 12 published months; every month present in `breakdown` including gaps; `no_published_data` empty state; `no_raster_data` on a single card. `/series`: `indicators` subset returns only those series; null-filled gaps; unpublished months excluded (D-4); 400s for bad month format, `from > to`, span > 120 (both explicit and `from`-only against the default `to`), unknown indicator; 404 for unknown administration. Query-count assertions (5 / 4) so a future refactor cannot reintroduce an N+1. |
+| E2E | Frontend CDI Explorer tab: strip renders 12 cells for a seeded Inkhundla, a chart's date picker refetches only its own series. |
+
+New files: `api/v1/v1_publication/tests/tests_cdi_explorer_stats.py` and
+`tests_cdi_explorer_series.py`, on a shared `mixins.py` fixture (the pattern
+`v1_weather/tests/mixins.py` established). Covered by the CI `test.sh` run.
+
+---
+
+## 10. Open Questions
+
+- [ ] **Figma units/subtitle owner** — chart *titles* are settled (they stay
+      as designed, D-5). Still wrong in the design file: the four subtitles
+      (`mm / month`, `Degrees °C`, `m³/m³`, `Normalised Difference Vegetation
+      Index · 0–1`), the four y-axis ranges (`0–3k`, `25°–37°`, …) and the
+      metric-card sample values — every series is a `0–1` percentile rank
+      (§1.1). Who lands that, and does it block the frontend tab?
+
+### Resolved 2026-07-27
+
+- [x] **Chart titles** — keep the Figma wording ("LST", "NDVI", CHIRPS,
+      SMAP) as *frontend* copy; the API serves ESI / EVI2 / SPI-3 / NOAH under
+      their own index names (§1.1, D-5).
+- [x] **Export CSV** — out of scope; no endpoint (§4).
+- [x] **Metric-card period label** — cards show the actual period from
+      `meta.period`, not the literal words "last month" (§4).
+- [x] **D-class strip window** — last 12 *published* months, ascending; same
+      fetch convention as `frontend/src/app/detailed-insights/`, no
+      agricultural-year boundary (D-11).
+- [x] **Months with no publication at all** — one "No data" cell, visually
+      identical to a published month carrying no decision; both are
+      `value: null` (§4).
+
+---
+
+## 11. References
+
+- Figma: [Detailed insights → CDI Explorer, `3483-57786`](https://www.figma.com/design/gtNfp5n7NawbYW5u8cPrpT/Eswatini-Drought-platform?node-id=3483-57786&m=dev)
+- Prior art (contract shape this mirrors): [`weather-explorer-public-api.md`](weather-explorer-public-api.md) — WX-4
+- Data source: [`publication-raster-extraction.md`](publication-raster-extraction.md) — `PublicationRaster`, D-4 (percentile ranks, no categories)
+- Superseded (backend half): [`../specs/INS-1_insights_cdi_explorer.md`](../specs/INS-1_insights_cdi_explorer.md)
+- Sibling tab: [`iks_explorer_backend.md`](iks_explorer_backend.md)
+- Shared frontend component: [`frontend/src/components/Insights/InkhundlaHeader.js`](../../../frontend/src/components/Insights/InkhundlaHeader.js)
+- Fetch convention this tab copies (D-11): [`frontend/src/hooks/useWeatherSeries.js`](../../../frontend/src/hooks/useWeatherSeries.js) · [`frontend/src/components/Insights/WeatherTab/`](../../../frontend/src/components/Insights/WeatherTab/) · the tab this replaces: [`frontend/src/app/detailed-insights/page.js`](../../../frontend/src/app/detailed-insights/page.js) (placeholder)
+
+---
+
+## Approval
+
+| Role | Name | Date | Status |
+|------|------|------|--------|
+| Developer | Iwan Firmawan | 2026-07-27 | Implemented |
+| Tech Lead | | | |
+| Product | | | |

--- a/frontend/src/app/(auth)/reviews/[id]/[administrationId]/__tests__/WeatherColumn.test.js
+++ b/frontend/src/app/(auth)/reviews/[id]/[administrationId]/__tests__/WeatherColumn.test.js
@@ -3,7 +3,12 @@ import { WeatherColumn } from "../IndividualReview";
 
 const metWeather = {
   data: [
-    { key: "min_temperature", label: "Min temperature", value: 12, units: "°C" },
+    {
+      key: "min_temperature",
+      label: "Min temperature",
+      value: 12,
+      units: "°C",
+    },
     {
       key: "soil_temperature",
       label: "Soil temperature",
@@ -17,7 +22,12 @@ const metWeather = {
 
 const csReading = {
   data: [
-    { key: "precipitation", label: "Precipitation (monthly)", value: 55, units: "mm" },
+    {
+      key: "precipitation",
+      label: "Precipitation (monthly)",
+      value: 55,
+      units: "mm",
+    },
     { key: "soil_moisture", label: "Soil moisture", value: null, units: "%" },
   ],
   meta: {

--- a/frontend/src/app/(auth)/validations/[id]/page.js
+++ b/frontend/src/app/(auth)/validations/[id]/page.js
@@ -36,6 +36,18 @@ import {
 import dayjs from "dayjs";
 import { PublishModal, ReviewerPanelModal } from "@/components/Validation";
 
+/**
+ * First message out of a DRF error body, whichever field it came from.
+ * Reading only `status` was enough while the publish payload carried one
+ * validatable field; with `bulletin_url` alongside it, a mistyped URL would
+ * otherwise surface as the generic "Publish failed." with the real reason
+ * ("Enter a valid URL.") dropped on the floor.
+ */
+const firstError = (res) =>
+  Object.values(res || {})
+    .flat()
+    .find((value) => typeof value === "string") ?? "Publish failed.";
+
 const STATUS_FILTERS = [
   { label: "All", value: "all" },
   { label: "Ready", value: "ready" },
@@ -444,7 +456,9 @@ const ValidationDetailPage = () => {
                   disabled={!meta?.can_publish}
                   onClick={() => setPublishOpen(true)}
                 >
-                  Publish validated map
+                  {publishedDate
+                    ? "Update published map"
+                    : "Publish validated map"}
                 </Button>
               </Tooltip>
             </div>
@@ -643,16 +657,20 @@ const ValidationDetailPage = () => {
       <PublishModal
         open={publishOpen}
         yearMonth={meta?.year_month}
+        currentNarrative={meta?.narrative}
+        currentBulletinUrl={meta?.bulletin_url}
+        published={!!publishedDate}
         onCancel={() => setPublishOpen(false)}
-        onPublish={async ({ narrative }) => {
+        onPublish={async ({ narrative, bulletinUrl }) => {
           // api() resolves on 4xx rather than rejecting, so a failed publish
           // has to be detected from the body — never from a catch block.
           const res = await api("PUT", `/admin/publication/${id}`, {
             status: PUBLICATION_STATUS.published,
             narrative,
+            bulletin_url: bulletinUrl,
           });
           if (res?.status !== PUBLICATION_STATUS.published) {
-            return res?.status?.[0] ?? "Publish failed.";
+            return firstError(res);
           }
           setPublishOpen(false);
           fetchData();

--- a/frontend/src/components/Insights/InkhundlaHeader.js
+++ b/frontend/src/components/Insights/InkhundlaHeader.js
@@ -73,7 +73,7 @@ const InkhundlaHeader = ({ name, region = "", zone = "", dclass = null }) => {
       >
         <div
           style={{ backgroundColor: chipBg }}
-          className="flex items-center justify-center px-[4px] py-[1px] rounded-[4px] shrink-0 w-[36px]"
+          className="flex items-center justify-center px-[4px] py-[1px] rounded-[4px] shrink-0"
         >
           <p
             style={{ color: readableInk(chipBg) }}

--- a/frontend/src/components/Validation/PublishModal.js
+++ b/frontend/src/components/Validation/PublishModal.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Alert, Button, Input, Modal } from "antd";
 import { WarningFilled } from "@ant-design/icons";
 import dayjs from "dayjs";
@@ -22,10 +22,32 @@ export const overviewTitle = (yearMonth) =>
     yearMonth ? dayjs(yearMonth, "YYYY-MM").format("MMMM YYYY") : "this month"
   }`;
 
-const PublishModal = ({ open, yearMonth, onCancel, onPublish }) => {
-  const [narrative, setNarrative] = useState("");
+const PublishModal = ({
+  open,
+  yearMonth,
+  currentNarrative,
+  currentBulletinUrl,
+  published = false,
+  onCancel,
+  onPublish,
+}) => {
+  const [narrative, setNarrative] = useState(currentNarrative || "");
+  const [bulletinUrl, setBulletinUrl] = useState(currentBulletinUrl || "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+
+  // `destroyOnClose` only unmounts the Modal's children — this state lives in
+  // the wrapper and survives, so on first mount it is seeded from a `meta`
+  // that has not been fetched yet. Re-seed each time the modal opens, not on
+  // every prop change, or a refetch mid-edit would overwrite what is typed.
+  useEffect(() => {
+    if (open) {
+      setNarrative(currentNarrative || "");
+      setBulletinUrl(currentBulletinUrl || "");
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const handlePublish = async () => {
     if (!narrative.trim()) {
@@ -37,7 +59,13 @@ const PublishModal = ({ open, yearMonth, onCancel, onPublish }) => {
     // onPublish resolves with an error message, or null on success. The API
     // helper resolves on 4xx rather than rejecting, so a rejected publish is
     // a value to inspect — not an exception to catch.
-    const message = await onPublish?.({ narrative });
+    // The bulletin URL is optional: an empty box means "no bulletin", and is
+    // sent as such so clearing one actually clears it. Its format is left to
+    // the backend's URLField so there is one definition of a valid URL.
+    const message = await onPublish?.({
+      narrative,
+      bulletinUrl: bulletinUrl.trim(),
+    });
     setSaving(false);
     if (message) {
       setError(message);
@@ -69,7 +97,9 @@ const PublishModal = ({ open, yearMonth, onCancel, onPublish }) => {
 
             <div className="flex flex-col gap-2">
               <h2 className="text-xl font-semibold text-[#333333]">
-                Publish validated drought map
+                {published
+                  ? "Update published drought map"
+                  : "Publish validated drought map"}
               </h2>
               <p className="text-sm text-[#606060]">
                 This replaces the current National Overview. The headline and
@@ -105,6 +135,26 @@ const PublishModal = ({ open, yearMonth, onCancel, onPublish }) => {
                 <span className="text-xs text-[#606060]">
                   Two-to-three sentences summarising the situation across the
                   country.
+                </span>
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="publish-bulletin-url"
+                  className="text-sm font-normal text-[#606060]"
+                >
+                  Bulletin URL <span className="text-[#909090]">(optional)</span>
+                </label>
+                <Input
+                  id="publish-bulletin-url"
+                  type="url"
+                  placeholder="https://example.org/bulletin-2026-05.pdf"
+                  value={bulletinUrl}
+                  onChange={(e) => setBulletinUrl(e.target.value)}
+                />
+                <span className="text-xs text-[#606060]">
+                  Link to the full bulletin for this month. Leave empty if
+                  there is none.
                 </span>
               </div>
             </div>
@@ -151,7 +201,7 @@ const PublishModal = ({ open, yearMonth, onCancel, onPublish }) => {
             loading={saving}
             onClick={handlePublish}
           >
-            Publish
+            {published ? "Update" : "Publish"}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/Validation/__tests__/PublishModal.test.js
+++ b/frontend/src/components/Validation/__tests__/PublishModal.test.js
@@ -25,6 +25,11 @@ const type = (value) =>
     target: { value },
   });
 
+const bulletinInput = () => screen.getByLabelText(/bulletin url/i);
+
+const typeBulletin = (value) =>
+  fireEvent.change(bulletinInput(), { target: { value } });
+
 const publish = () =>
   fireEvent.click(screen.getByRole("button", { name: /^publish$/i }));
 
@@ -51,17 +56,92 @@ describe("PublishModal", () => {
     expect(screen.getAllByText("Auto-generated")).toHaveLength(4);
   });
 
-  it("submits only the description", async () => {
+  it("submits the description and the bulletin URL", async () => {
     const onPublish = jest.fn().mockResolvedValue(null);
     render(<PublishModal open yearMonth="2026-05" onPublish={onPublish} />);
 
     type("Conditions eased across the Lowveld.");
+    typeBulletin("  https://ndma.org.sz/bulletin-2026-05.pdf  ");
     publish();
 
     await waitFor(() => expect(onPublish).toHaveBeenCalledTimes(1));
     expect(onPublish).toHaveBeenCalledWith({
       narrative: "Conditions eased across the Lowveld.",
+      bulletinUrl: "https://ndma.org.sz/bulletin-2026-05.pdf",
     });
+  });
+
+  it("publishes without a bulletin URL — it is optional", async () => {
+    const onPublish = jest.fn().mockResolvedValue(null);
+    render(<PublishModal open yearMonth="2026-05" onPublish={onPublish} />);
+
+    type("No bulletin this month.");
+    publish();
+
+    await waitFor(() => expect(onPublish).toHaveBeenCalledTimes(1));
+    expect(onPublish).toHaveBeenCalledWith({
+      narrative: "No bulletin this month.",
+      bulletinUrl: "",
+    });
+  });
+
+  it("sends an emptied bulletin URL so clearing one actually clears it", async () => {
+    const onPublish = jest.fn().mockResolvedValue(null);
+    const { rerender } = render(
+      <PublishModal open={false} yearMonth="2026-05" onPublish={onPublish} />,
+    );
+    rerender(
+      <PublishModal
+        open
+        yearMonth="2026-05"
+        currentNarrative="Hello world"
+        currentBulletinUrl="https://ndma.org.sz/old.pdf"
+        published
+        onPublish={onPublish}
+      />,
+    );
+
+    typeBulletin("");
+    fireEvent.click(screen.getByRole("button", { name: /^update$/i }));
+
+    await waitFor(() => expect(onPublish).toHaveBeenCalledTimes(1));
+    expect(onPublish).toHaveBeenCalledWith({
+      narrative: "Hello world",
+      bulletinUrl: "",
+    });
+  });
+
+  it("seeds the description and bulletin URL from the published map, and says Update", () => {
+    // `meta` arrives after the first render, so seeding only in useState
+    // leaves an already-published map editing an empty box (bug: #317).
+    // The modal submits both fields on every update, so a field it fails to
+    // seed is a field it silently wipes.
+    const { rerender } = render(
+      <PublishModal open={false} yearMonth="2026-05" onPublish={jest.fn()} />,
+    );
+    rerender(
+      <PublishModal
+        open
+        yearMonth="2026-05"
+        currentNarrative="Hello world"
+        currentBulletinUrl="https://ndma.org.sz/bulletin-2026-05.pdf"
+        published
+        onPublish={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByPlaceholderText("Shown underneath the title"),
+    ).toHaveValue("Hello world");
+    expect(bulletinInput()).toHaveValue(
+      "https://ndma.org.sz/bulletin-2026-05.pdf",
+    );
+    expect(
+      screen.getByRole("button", { name: /^update$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^publish$/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("requires a description before it will submit", async () => {


### PR DESCRIPTION
Track 3 Detailed insights → **CDI Explorer** tab. Two public endpoints serve
the whole frame per Inkhundla — header context, the 12-cell D-class history
strip, four metric cards and four range-filtered monthly charts — built
entirely from data already in the database: **no new model, no migration, no
new extraction pipeline.** Also lands the publish modal's optional bulletin
URL and the prefill fix that keeps an update from wiping it.

Design doc:
[`track-3/cdi-explorer-backend-api.md`](eswatini-v2/docs/track-3/cdi-explorer-backend-api.md)
(INS-3). Supersedes the backend half of
[`specs/INS-1_insights_cdi_explorer.md`](eswatini-v2/docs/specs/INS-1_insights_cdi_explorer.md).
Contract shape mirrors WX-4
([`track-3/weather-explorer-public-api.md`](eswatini-v2/docs/track-3/weather-explorer-public-api.md)).
Figma: [CDI Explorer `3483-57786`](https://www.figma.com/design/gtNfp5n7NawbYW5u8cPrpT/Eswatini-Drought-platform?node-id=3483-57786&m=dev).

---

## ⚠️ The parts worth reading first

**1. Zero new schema — the data was already there, just unreachable.**
`PublicationRaster` (per-Inkhundla zonal values for esi/evi2/sm/spi, extracted
automatically at publication create time) had **no public reader at all**.
INS-1 shipped this tab frontend-only, assembling the D-class history from
`GET /dates` plus one `GET /map/{id}` per month — 13 round trips per Inkhundla,
each transferring all 59 Tinkhundla to use a single row, ~700 discarded records
per page view. And it could never serve the indicator charts, because
`/map/{id}` exposes `validated_values` only. One `/stats` call replaces the
lot. INS-1's D-2 still stands as the *source of truth* statement; only its
transport decision is superseded.

**2. The chart titles name datasets the pipeline does not produce.**
Confirmed with the CDI pipeline: the four charts titled CHIRPS / NDVI / LST /
SMAP in the design are actually **SPI-3 (`chirps_spi_3mn`) / EVI2 (`evi2_1mn`)
/ ESI (`era5_esi_1mn`) / NOAH soil moisture (`noah_soilm_1mn`)**. Product kept
the designed wording — "LST" and "NDVI" are the words the TWG audience reads —
so the substitution is real and permanent.

The API therefore **speaks only in index keys** (`spi`/`evi2`/`esi`/`sm`, which
are the `PublicationRaster.indicator` values `?indicators=` filters on) with
`label` from the existing `FieldStr`. The titles are frontend copy, per the
CLAUDE.md rule that derived display config never comes from the API — an
earlier draft carried a `DISPLAY_LABELS` map and a `SOURCES` map in the
backend; both were dropped in review as things the backend does not need.

**Consequence the design file still has to absorb:** all four series are
**percentile ranks on a common 0–1 scale** (`STEP_0303_*_pct_rank`). There is
no `mm`, no `°C`, no `m³/m³` anywhere here — the API reports
`units: "pct_rank"` throughout, so the Figma subtitles (`mm / month`,
`Degrees °C`, `m³/m³`), the y-axis ranges (`0–3k`, `25°–37°`) and the sample
card values are placeholder copy. That is the one open question left.

**3. Published-only, deliberately.** Component rasters are extracted at
publication *create* time, so an unpublished month **already has indicator
values sitting in the table**. Serving them on a public, anonymous-readable
surface would leak a map still under TWG review — and the four charts would
silently run a month ahead of the D-class strip beside them. Both endpoints
filter `status=published, published_at__isnull=False`, so the strip, the cards
and the charts always share one window and one "latest month".

**4. The default window is anchored on publication, not on today.** WX-4
defaults to calendar-year-to-date, which works because the WIS2 archive is
daily and current. CDI publishes 1–2 months in arrears, so calendar-YTD in July
would return four published months and seven empty ones next to a strip
specified as 12 filled cells. Default here is **the last 12 published months**,
ending at the latest published month. The fetch *mechanism* still copies
`useWeatherSeries` exactly — one call per chart, `{from, to}` as `"YYYY-MM"`,
omitted on first load so the backend owns the default.

**5. Two helpers moved to where they belong — neither was copied.**
- `current_dclass` → `v1_publication/insights/utils.py`. Every Detailed
  Insights tab renders the same chip, so the rule needs exactly one definition,
  beside the model it reads. `v1_weather.services._current_dclass` is **deleted,
  not wrapped**: its deferred in-function import was dodging a cycle that does
  not exist (`v1_publication` imports nothing from `v1_weather`), so the import
  moved to module top and the one-caller wrapper was pure indirection.
- `month_range` → `utils/periods.py` (with `month_start`, `shift_period`,
  `period_span`). It already existed in `v1_weather/services.py` and INS-3
  needed the same inclusive `YYYY-MM` padding; calendar arithmetic belongs to
  neither app. The existing WX-4 tests are the parity check on both moves and
  pass untouched.

---

## API surface

| Method | URL | Purpose | Auth |
|---|---|---|---|
| GET | `/cdi/administrations/{id}/stats` | header context + D-class history strip + 4 metric cards | public |
| GET | `/cdi/administrations/{id}/series?indicators=&from=&to=` | the 4 chart series, or a subset | public |

Public (`AllowAny`) to match the sibling Weather and IKS Explorer tabs on the
same page — a CDI tab that 401s beside them reads as a bug, and everything
served is derived from already-public published maps.

Query params are validated by a DRF serializer with `raise_exception=True`.
`from`/`to` are inclusive `YYYY-MM`; `indicators` is a comma-separated subset,
validated against `RasterIndicatorTypes` so the value reaches the ORM only as
an `indicator__in` list of known constants. Bad month format, `from > to`,
span > 120 months, or an unknown indicator → **400**; unknown administration →
**404** via `get_object_or_404`. The span cap lives in `resolve_window()`, not
the serializer — with only `from` supplied the span is not knowable until `to`
has fallen back to the latest published month, so `?from=1900-01` alone is
caught too.

**Contract keys stay generic** (`key`/`label`/`value`/`data`/`group`/`period`/
`meta`/`breakdown`) and carry **no drought labels or colors** — those stay in
`static/config.js`. The D-class strip rides in `breakdown`:

```json
"breakdown": {"group": "dclass_history",
              "data": [{"period": "2025-06", "value": 3},
                       {"period": "2025-07", "value": null}]}
```

Every month in the window is present in the strip **and** in every series, with
`value: null` for gaps — so a chart's x-axis is honest about missing months
instead of compressing them, and the 12-cell strip never shifts. `-9999`
(`DroughtCategory.none`) is passed through untouched rather than flattened to
null; it is real published output meaning "the CDI had no signal", and the
frontend already maps it to its own No-data chip.

Cards carry `previous`, `previous_period` and a **signed** `change_pct` (1dp).
`change_pct` is `null`, never `0`, when the previous month is missing or zero —
the card then omits its delta row instead of claiming "no change". Arrow glyph
and color are the frontend's, derived from the sign; the Figma mock shows an
up-arrow on a decrease, which is mock drift, not a rule. Cards render the
**actual period** from `meta.period`, not the literal words "Last month's …",
because publication lag puts it 1–2 months behind the calendar.

Empty states follow the WX-4 convention: no published publication **at all** →
`data: null, breakdown: null, meta.reason: "no_published_data"`, with the header
block still returned so the page renders. An Inkhundla that simply never
appears in a published month is *not* that case — it gets the full window with
`null` throughout. A single index with no extracted raster →
`value: null` + `meta.reason: "no_raster_data"` on that card only.

**Query cost is bounded and asserted**: 5 queries for `/stats`, 4 for
`/series`, independent of window size, with `assertNumQueries` guarding against
a future refactor reintroducing an N+1. `current_dclass` keeps its own query
rather than reusing the window's latest — it filters on `validated_values`, not
`published_at`, and matching WX-4's existing behaviour exactly is worth more
than saving one indexed lookup. No GeoNode call on the read path, so an
upstream outage cannot be induced from here.

Code lives in a new `v1_publication/insights/` subpackage
(`view.py`/`serializers.py`/`utils.py`), matching the established `review/`,
`validation/` and `twg/` shape — `views.py` is already 1265 lines. URLs are
under `/cdi/` and **anchored with a trailing `$`**, registered above the
unanchored `/admin/publication/{pk}` pattern, which `urls.py` already carries
two hard-won warnings about swallowing anything nested below it.

## Publish modal: optional bulletin URL

`Publication.bulletin_url` has existed and been writable on
`PublicationSerializer` all along; the modal just never offered it. Adds the
optional field (`type="url"`, label-associated), submitted trimmed, with format
validation left to the backend's `URLField` so there is one definition of a
valid URL.

**The prefill is load-bearing, not cosmetic.** The modal submits every field on
each update, so a field it cannot seed is a field it **silently wipes** —
exactly the bug just fixed for `narrative`. `ValidationMetaSerializer` now
carries both `narrative` and `bulletin_url`, and both sides are tested:
re-opening "Update published drought map" edits the live values instead of
blanking them, and clearing the box still clears the URL.

Error surfacing was widened alongside it: the page read `res?.status?.[0]`,
fine while `status` was the only validatable field. With a URL in the payload a
mistyped link returns `{"bulletin_url": ["Enter a valid URL."]}`, which would
have shown as the generic "Publish failed." A `firstError` helper now pulls the
real message out of whichever field failed.

Also here: `InkhundlaHeader`'s D-class chip drops its fixed `w-[36px]`, so
longer codes stop being clipped.

## Cron drift check

`test_every_cron_task_is_handled_by_job_sh` failed on `cs-reminders`. The code
was fine — `job.sh` handles the task and `eswatini-cron` schedules it for 07:00
on the 1st — but the task-name extraction used `(\w+)`, which cannot match a
hyphen, so `job.sh`'s known tasks read as `{rasters, reviews, weather}`.

Worth noting the failure mode, since this test exists specifically to catch
drift: the same gap made the **sibling** assertion
`test_every_job_sh_task_is_scheduled` skip `cs-reminders` entirely — it was
passing while checking nothing about it. A drift check with a hole exactly
where a hyphenated task appears is worse than no check. Both assertions cover
it now.

## Testing

- **Backend: 654 tests green**, flake8 clean on changed files. 25 new CDI
  Explorer tests on a shared `tests/mixins.py` fixture (the pattern
  `v1_weather/tests/mixins.py` established), plus the validation-meta cases.
  The fixture deliberately encodes the nasty shapes — a calendar gap month, a
  published month carrying no decision, and one missing raster — so padding,
  `null` strip cells and `no_raster_data` are all *covered* rather than
  assumed. Also: `-9999` pass-through, `change_pct` sign/rounding/null cases,
  `indicators` subsetting, unpublished months excluded, every 400 and 404 path,
  and the query-count assertions.
- **Frontend: 178 tests green**, ESLint clean. 4 new `PublishModal` cases
  (submits the URL, publishes without it, clearing it actually clears, seeding
  from a published map).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216095015950025