### PR TITLE
[#141] refactor(frontend): remove map category filter dropdown

### DIFF
--- a/frontend/src/app/(auth)/publications/__tests__/publications.test.js
+++ b/frontend/src/app/(auth)/publications/__tests__/publications.test.js
@@ -344,22 +344,6 @@ describe("PublicationsPage", () => {
     });
   });
 
-  it("handles category selection change", async () => {
-    render(<PublicationsPage />);
-
-    await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
-
-    const categorySelect = screen.getByTestId("mock-select");
-    fireEvent.change(categorySelect, { target: { value: "spi-raster-map" } });
-
-    await waitFor(() => {
-      expect(api).toHaveBeenLastCalledWith(
-        "GET",
-        expect.stringContaining("category=spi-raster-map"),
-      );
-    });
-  });
-
   it("handles table sorting change", async () => {
     const { container } = render(<PublicationsPage />);
 

--- a/frontend/src/app/(auth)/publications/page.js
+++ b/frontend/src/app/(auth)/publications/page.js
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Modal, Select, Table, Tag } from "antd";
+import { Button, Modal, Table, Tag } from "antd";
 import { FileOutlined } from "@ant-design/icons";
 import {
   Can,
@@ -34,7 +34,6 @@ const PublicationsPage = () => {
   const [preload, setPreload] = useState(true);
   const [totalData, setTotalData] = useState(0);
   const [page, setPage] = useState(1);
-  const [category, setCategory] = useState(MAP_CATEGORY_OPTIONS[0].value);
   const [statusFilter, setStatusFilter] = useState("all");
   const [sortField, setSortField] = useState("year_month");
   const [sortOrder, setSortOrder] = useState("descend");
@@ -181,7 +180,7 @@ const PublicationsPage = () => {
 
         const params = new URLSearchParams({
           page,
-          category,
+          category: MAP_CATEGORY_OPTIONS[0].value,
           sort: sortField,
           sort_order,
         });
@@ -209,7 +208,7 @@ const PublicationsPage = () => {
       setLoading(false);
       setPreload(false);
     }
-  }, [preload, page, statusFilter, category, sortField, sortOrder]);
+  }, [preload, page, statusFilter, sortField, sortOrder]);
 
   useEffect(() => {
     fetchData();
@@ -252,22 +251,6 @@ const PublicationsPage = () => {
                   setPage(1);
                   setPreload(true);
                 }}
-              />
-              <Select
-                options={MAP_CATEGORY_OPTIONS}
-                className="w-full lg:w-48"
-                placeholder="Filter by Category"
-                onChange={(value) => {
-                  setPage(1);
-                  if (value) {
-                    setCategory(value);
-                  } else {
-                    setCategory(MAP_CATEGORY_OPTIONS[0].value);
-                  }
-                  setPreload(true);
-                }}
-                value={category}
-                allowClear={false}
               />
             </div>
             <Table


### PR DESCRIPTION
# Pull Request Description

**Target Branch**: `develop`  
**Feature Branch**: `feature/141-track-2-cdi-publication-frontend-page-refactoring`  
**Issue Reference**: `#141`  

---

## 1. What
This PR removes the redundant map category selection filter dropdown from the CDI Publications page. 

Key changes:
1. **Frontend UI Cleanup** (`frontend/src/app/(auth)/publications/page.js`):
   - Removed the `<Select>` component for category selection from the filter bar.
   - Removed the `category` and `setCategory` state variables, and cleaned up the unused `Select` import from `antd`.
   - Hardcoded the `category: MAP_CATEGORY_OPTIONS[0].value` query parameter inside the `fetchData` function, keeping the default `"cdi"` map category filtering intact.
   - Removed the `category` variable from the `useCallback` dependency array.
2. **Integration Test Alignment** (`frontend/src/app/(auth)/publications/__tests__/publications.test.js`):
   - Deleted the obsolete `"handles category selection change"` unit test.

---

## 2. Why
Since the platform is designed to manage and track CDI map publications specifically, filtering by other map categories is unnecessary. Removing this dropdown simplifies the filter interface and matches the validations page UX.

---

## 3. How
- **Hardcoded Query Parameter**: Constructed the `URLSearchParams` object in the API fetch logic using `MAP_CATEGORY_OPTIONS[0].value` directly.
- **State Removal**: Removed the component-level React state hook for `category`, reducing unnecessary renders.

---

## 4. Verification & Testing
All frontend tests pass:
* Run Next.js static lint checks:
  ```bash
  docker compose exec frontend yarn lint
  ```
* Run Jest unit tests:
  ```bash
  docker compose exec frontend ./test.sh
  ```
  Result: **29/29 suites passed (174/174 tests passed).**
